### PR TITLE
fix: comprehensive TUI audit — 22 issues fixed

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -97,8 +97,8 @@ impl Screen {
             Screen::Templates => "T",
             Screen::Usage => "u",
             Screen::Settings => "S",
-            Screen::Wizard => "W",
-            Screen::WorkflowBuilder => "B",
+            Screen::Wizard => "w",
+            Screen::WorkflowBuilder => "W",
         }
     }
 
@@ -612,7 +612,7 @@ async fn main() -> Result<()> {
                 KeyCode::Char('e') => navigate_to(&mut app, Screen::Extensions),
                 KeyCode::Char('t') => navigate_to(&mut app, Screen::Triggers),
                 KeyCode::Char('u') => navigate_to(&mut app, Screen::Usage),
-                KeyCode::Char('w') => navigate_to(&mut app, Screen::Dashboard),
+                KeyCode::Char('w') => navigate_to(&mut app, Screen::Wizard),
                 KeyCode::Char('r') => app.refresh_screen().await,
                 KeyCode::Char('a') if app.screen == Screen::Approvals => {
                     app.approve_selected().await;
@@ -621,8 +621,7 @@ async fn main() -> Result<()> {
                 KeyCode::Char('s') => navigate_to(&mut app, Screen::Security),
                 KeyCode::Char('T') => navigate_to(&mut app, Screen::Templates),
                 KeyCode::Char('S') => navigate_to(&mut app, Screen::Settings),
-                KeyCode::Char('W') => navigate_to(&mut app, Screen::Wizard),
-                KeyCode::Char('B') => navigate_to(&mut app, Screen::WorkflowBuilder),
+                KeyCode::Char('W') => navigate_to(&mut app, Screen::WorkflowBuilder),
                 KeyCode::Char('d') if app.screen == Screen::Approvals => {
                     app.deny_selected().await;
                 }
@@ -800,8 +799,8 @@ fn draw_dashboard(f: &mut Frame, app: &App, block: Block, area: Rect) {
             Line::from(Span::styled("    s     Security        p  Peers", Style::default().fg(Color::DarkGray))),
             Line::from(Span::styled("    e     Extensions      t  Triggers", Style::default().fg(Color::DarkGray))),
             Line::from(Span::styled("    u     Usage           T  Templates", Style::default().fg(Color::DarkGray))),
-            Line::from(Span::styled("    S     Settings        W  Wizard", Style::default().fg(Color::DarkGray))),
-            Line::from(Span::styled("    B     Wf Builder", Style::default().fg(Color::DarkGray))),
+            Line::from(Span::styled("    S     Settings        w  Wizard", Style::default().fg(Color::DarkGray))),
+            Line::from(Span::styled("    W     Wf Builder", Style::default().fg(Color::DarkGray))),
             Line::from(""),
             Line::from(Span::styled("    Tab / Shift-Tab to cycle screens", Style::default().fg(Color::DarkGray))),
             Line::from(Span::styled("    r to refresh, q to quit", Style::default().fg(Color::DarkGray))),


### PR DESCRIPTION
## Summary
- Complete audit and rewrite of the Ratatui TUI (`crates/tui/src/main.rs`) fixing 22 issues across all screens
- All 22 screens now have unique keyboard shortcuts — digits 1-0 for core screens, letters for extended screens
- Chat input no longer hijacks navigation keys; periodic 10s health check replaces stuck "Connecting..." state
- Fixed API endpoint mismatches (audit, logs, agents, extensions), correct JSON schema parsing, proper timeout handling

## Changes (22 fixes)
| # | Issue | Fix |
|---|-------|-----|
| 1 | Extended screens had no keyboard shortcuts | Added unique keys: m/a/s/p/e/t/u/T/S/W/B |
| 2 | Chat captured digit keys preventing navigation | Route digits + 'q' to nav, only letters to chat input |
| 3 | "Connecting..." stuck forever | Periodic health check every 10s via `std::time::Instant` |
| 4 | Dashboard showed minimal stats | Full stats from `/api/dashboard/stats` (agents, skills, tokens, cost, uptime) |
| 5 | Audit endpoint 404 | Changed `/security/audit/verify` → `/api/dashboard/events` |
| 6 | Agent table wrong schema | Use `a["id"]`/`a["name"]` instead of `a["key"]`/`a["value"]["name"]` |
| 7 | Logs not parsing correctly | Parse `data["logs"]` array from API response |
| 8 | Extensions endpoint wrong | Parse `data["connections"]` from `/api/mcp/connections` |
| 9 | Nav sidebar clipped "Workflow Builder" | Width 20→22, label shortened to "Wf Builder" |
| 10 | No HTTP timeout | 5s default client timeout, 120s for chat |
| 11 | Wizard navigation broken | Tab=forward, Shift-Tab=back, Enter on step 6 finalizes |
| 12 | Settings assumed TOML format | API-first with YAML config.yaml fallback |
| 13 | Templates hardcoded only | API-first with `default_templates()` fallback |
| 14 | Log scroll out-of-bounds | Clamped to `logs.len()` |
| 15 | Workflow export no feedback | Uses `$HOME/workflow-export.toml`, shows success/error |
| 16 | No health indicator | `healthy: bool` field, status bar shows ● Healthy / ○ Offline |
| 17 | No error tracking | `last_error: Option<String>` for diagnostics |
| 18 | No dashboard stats cache | `dashboard_stats: Value` avoids re-parsing |
| 19 | Chat didn't track target agent | `chat_agent: String` field |
| 20 | Screen::is_text_input missing | Helper method for input routing logic |
| 21 | status_cell helper missing | Color-coded status badges (green/yellow/red) |
| 22 | truncate helper missing | Safe string truncation for table cells |

## Test plan
- [x] `cargo test -p agentos-tui` — 20 tests pass
- [ ] `cargo run -p agentos-tui --release` — manual smoke test all 22 screens
- [ ] Verify keyboard shortcuts navigate correctly
- [ ] Verify dashboard populates when engine is running