### PR TITLE
fix: website quickstart uses cargo install, not npm

### DIFF
--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -5,11 +5,11 @@ import FadeIn from "./shared/FadeIn";
 import { stats } from "../data/stats";
 
 const TERMINAL_LINES = [
-  { text: "$ agentos init --template coder", type: "command" },
-  { text: "  Agent created: coder-01", type: "success" },
-  { text: '$ agentos run "review PR #42"', type: "command" },
-  { text: "  routing to tools: [git, code, search]", type: "info" },
-  { text: "  streaming response...", type: "info" },
+  { text: "$ cargo install agentos", type: "command" },
+  { text: "  Installed agentos v0.1.0", type: "success" },
+  { text: "$ agentos start", type: "command" },
+  { text: "  18 Rust crates + 39 TS workers started", type: "info" },
+  { text: '$ agentos chat default "review PR #42"', type: "command" },
   { text: "  Review complete. 3 issues found.", type: "success" },
 ];
 

--- a/website/components/Quickstart.tsx
+++ b/website/components/Quickstart.tsx
@@ -4,20 +4,20 @@ import FadeIn from "./shared/FadeIn";
 import SectionHeader from "./shared/SectionHeader";
 
 const steps = [
-  { cmd: "npm install agentos", desc: "Install the AgentOS runtime" },
+  { cmd: "cargo install agentos", desc: "Install the AgentOS binary" },
   {
-    cmd: "agentos init --template coder",
+    cmd: "agentos init --quick",
     desc: "Scaffold a new agent project",
   },
   {
-    cmd: "agentos config set provider anthropic",
+    cmd: "agentos config set-key anthropic $ANTHROPIC_API_KEY",
     desc: "Configure your LLM provider",
   },
   {
-    cmd: "agentos tools add git code search",
-    desc: "Add tools to your agent",
+    cmd: "agentos start",
+    desc: "Start the engine and all workers",
   },
-  { cmd: "agentos run", desc: "Launch your agent" },
+  { cmd: "agentos chat default", desc: "Chat with your agent" },
 ];
 
 function CopyButton({ text }: { text: string }) {


### PR DESCRIPTION
## Summary

- Quickstart component: `npm install agentos` → `cargo install agentos` with correct CLI commands (`init --quick`, `config set-key`, `start`, `chat default`)
- Hero terminal animation: updated to show `cargo install` + `agentos start` flow with "18 Rust crates + 39 TS workers started"

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vite build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guide with revised installation and setup commands
  * Refreshed terminal demo to reflect the current workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->