### PR TITLE
refactor: remove iii-sdk duplication, use OTel API directly

### DIFF
--- a/src/__tests__/agent-core.test.ts
+++ b/src/__tests__/agent-core.test.ts
@@ -61,7 +61,6 @@ const mockTrigger = vi.fn(async (fnId: string, data?: any): Promise<any> => {
   if (fnId === "agent::delete") return { deleted: true };
   if (fnId === "publish") return null;
   if (fnId === "hook::fire") return null;
-  if (fnId === "telemetry::record") return { ok: true };
   return null;
 });
 const mockTriggerVoid = vi.fn();
@@ -85,6 +84,18 @@ vi.mock("iii-sdk", () => ({
     triggerVoid: mockTriggerVoid,
     listFunctions: mockListFunctions,
   }),
+  getContext: vi.fn(() => ({ logger: null })),
+}));
+
+const noopInstrument = { add: vi.fn(), record: vi.fn() };
+vi.mock("@opentelemetry/api", () => ({
+  metrics: {
+    getMeter: vi.fn(() => ({
+      createCounter: vi.fn(() => noopInstrument),
+      createHistogram: vi.fn(() => noopInstrument),
+      createUpDownCounter: vi.fn(() => noopInstrument),
+    })),
+  },
 }));
 
 vi.mock("../shared/errors.js", () => ({
@@ -183,7 +194,6 @@ beforeEach(() => {
       if (fnId === "context::compress") return { ok: true };
       if (fnId === "replay::record") return { ok: true };
       if (fnId === "agent::code_detect") return { hasCode: false, blocks: [] };
-      if (fnId === "telemetry::record") return { ok: true };
       if (fnId === "agent::list_tools")
         return [
           { function_id: "tool::web_search" },

--- a/src/__tests__/approval-extended.test.ts
+++ b/src/__tests__/approval-extended.test.ts
@@ -160,12 +160,11 @@ describe("approval::check extended", () => {
     expect(pubCalls.some(c => c[1].topic === "approval.requested")).toBe(true);
   });
 
-  it("sends to approval stream", async () => {
+  it("publishes approval request via publish", async () => {
     getScope("approval_policy").set("default", { tools: ["*"], timeoutMs: 300000 });
     await call("approval::check", { agentId: "stream-agent", toolName: "tool::y", params: {} });
-    const streamCalls = mockTriggerVoid.mock.calls.filter(c => c[0] === "stream::send");
-    expect(streamCalls.length).toBe(1);
-    expect(streamCalls[0][1].stream_name).toBe("approvals");
+    const pubCalls = mockTriggerVoid.mock.calls.filter(c => c[0] === "publish");
+    expect(pubCalls.some(c => c[1].topic === "approval.requested")).toBe(true);
   });
 
   it("uses custom timeoutMs from policy", async () => {

--- a/src/__tests__/streaming.test.ts
+++ b/src/__tests__/streaming.test.ts
@@ -13,7 +13,6 @@ const mockTrigger = vi.fn(async (fnId: string, data?: any): Promise<any> => {
       model: "test-model",
       usage: { input: 10, output: 20, total: 30 },
     };
-  if (fnId === "stream::send") return { ok: true };
   if (fnId === "agent::chat")
     return {
       content: "agent response text for testing purposes",
@@ -80,29 +79,6 @@ describe("stream::chat", () => {
     expect(result.body.usage).toBeDefined();
     expect(result.body.usage.input).toBe(10);
     expect(result.body.usage.output).toBe(20);
-  });
-
-  it("sends stream chunks via stream::send", async () => {
-    await call("stream::chat", {
-      body: { message: "test", sessionId: "s1" },
-      headers: { authorization: "Bearer test-key" },
-    });
-    const streamCalls = mockTrigger.mock.calls.filter(
-      (c) => c[0] === "stream::send",
-    );
-    expect(streamCalls.length).toBeGreaterThan(0);
-  });
-
-  it("sends done event at end of stream", async () => {
-    await call("stream::chat", {
-      body: { message: "test" },
-      headers: { authorization: "Bearer test-key" },
-    });
-    const streamCalls = mockTrigger.mock.calls.filter(
-      (c) => c[0] === "stream::send",
-    );
-    const lastStreamCall = streamCalls[streamCalls.length - 1];
-    expect(lastStreamCall[1].data.type).toBe("done");
   });
 
   it("uses default agentId when not provided", async () => {

--- a/src/agent-core.ts
+++ b/src/agent-core.ts
@@ -10,7 +10,7 @@ import { filterToolsByProfile } from "./tool-profiles.js";
 import { safeCall } from "./shared/errors.js";
 import { shutdownManager } from "./shared/shutdown.js";
 import { createLogger } from "./shared/logger.js";
-import { createRecordMetric } from "./shared/metrics.js";
+import { recordMetric } from "./shared/metrics.js";
 
 const log = createLogger("agent-core");
 
@@ -31,8 +31,6 @@ const CONTEXT_HEALTH_THRESHOLD = 60;
 function earlyResponse(content: string): ChatResponse {
   return { content, model: undefined, usage: undefined, iterations: 0 };
 }
-
-const recordMetric = createRecordMetric(triggerVoid);
 
 type TriggerFn = typeof trigger;
 type TriggerVoidFn = typeof triggerVoid;

--- a/src/approval-tiers.ts
+++ b/src/approval-tiers.ts
@@ -185,12 +185,6 @@ registerFunction(
       data: { approvalId, agentId: safeAgentId, toolId, tier },
     });
 
-    triggerVoid("stream::send", {
-      stream_name: "approvals",
-      group_id: "pending",
-      data: { approvalId, agentId: safeAgentId, toolId, tier },
-    });
-
     if (tier === "async") {
       return { approved: false, tier, status: "pending", approvalId };
     }

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -81,12 +81,6 @@ registerFunction(
       data: { requestId, agentId, toolName },
     });
 
-    triggerVoid("stream::send", {
-      stream_name: "approvals",
-      group_id: "pending",
-      data: request,
-    });
-
     return { required: true, approved: false, status: "pending", requestId };
   },
 );

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -2,13 +2,11 @@ import { initSDK } from "./shared/config.js";
 import { createHash } from "crypto";
 import { safeCall } from "./shared/errors.js";
 import { createLogger } from "./shared/logger.js";
-import { createRecordMetric } from "./shared/metrics.js";
+import { recordMetric } from "./shared/metrics.js";
 
 const log = createLogger("memory");
 
 const { registerFunction, trigger, triggerVoid } = initSDK("memory");
-
-const recordMetric = createRecordMetric(triggerVoid);
 
 interface MemoryEntry {
   id: string;

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,44 +1,25 @@
 import { getContext } from "iii-sdk";
 
-interface LogContext {
-  [key: string]: unknown;
-}
+type LogFn = (message: string, context?: Record<string, unknown>) => void;
 
-interface Logger {
-  info(message: string, context?: LogContext): void;
-  warn(message: string, context?: LogContext): void;
-  error(message: string, context?: LogContext): void;
-  debug(message: string, context?: LogContext): void;
-}
-
-export function createLogger(module: string): Logger {
-  function trySDKLogger() {
-    try {
-      return getContext().logger;
-    } catch {
-      return null;
-    }
-  }
-
-  function emit(level: string, message: string, context?: LogContext): void {
-    const sdkLogger = trySDKLogger();
+export function createLogger(module: string): Record<"info" | "warn" | "error" | "debug", LogFn> {
+  function emit(level: string, message: string, context?: Record<string, unknown>): void {
     const data = context ? { module, ...context } : { module };
 
-    if (sdkLogger) {
-      switch (level) {
-        case "error": sdkLogger.error(message, data); break;
-        case "warn": sdkLogger.warn(message, data); break;
-        case "debug": sdkLogger.debug(message, data); break;
-        default: sdkLogger.info(message, data); break;
+    try {
+      const logger = getContext().logger;
+      if (logger) {
+        (logger as any)[level]?.(message, data) ?? logger.info(message, data);
+        return;
       }
+    } catch {}
+
+    const entry = { timestamp: new Date().toISOString(), level, module, message, ...context };
+    const line = JSON.stringify(entry);
+    if (level === "error") {
+      process.stderr.write(line + "\n");
     } else {
-      const entry = { timestamp: new Date().toISOString(), level, module, message, ...context };
-      const line = JSON.stringify(entry);
-      if (level === "error") {
-        process.stderr.write(line + "\n");
-      } else {
-        process.stdout.write(line + "\n");
-      }
+      process.stdout.write(line + "\n");
     }
   }
 

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,14 +1,33 @@
-type TriggerVoidFn = (id: string, input: any) => void;
+import { metrics } from "@opentelemetry/api";
 
-export function createRecordMetric(triggerVoid: TriggerVoidFn) {
-  return function recordMetric(
-    name: string,
-    value: number,
-    labels: Record<string, string>,
-    type: "counter" | "histogram" | "gauge" = "counter",
-  ) {
-    try {
-      triggerVoid("telemetry::record", { name, value, labels, type });
-    } catch {}
-  };
+type MetricType = "counter" | "histogram" | "gauge";
+
+const meter = metrics.getMeter("agentos");
+
+const instrumentCache = new Map<string, any>();
+
+function getOrCreate(name: string, factory: () => any): any {
+  let instrument = instrumentCache.get(name);
+  if (!instrument) {
+    instrument = factory();
+    instrumentCache.set(name, instrument);
+  }
+  return instrument;
+}
+
+export function recordMetric(
+  name: string,
+  value: number,
+  labels: Record<string, string>,
+  type: MetricType = "counter",
+): void {
+  try {
+    if (type === "counter") {
+      getOrCreate(name, () => meter.createCounter(name)).add(value, labels);
+    } else if (type === "histogram") {
+      getOrCreate(name, () => meter.createHistogram(name)).record(value, labels);
+    } else if (type === "gauge") {
+      getOrCreate(name, () => meter.createUpDownCounter(name)).add(value, labels);
+    }
+  } catch {}
 }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -36,31 +36,6 @@ registerFunction(
       messages: [...memories, { role: "user", content: message }],
     });
 
-    const chunks = chunkMarkdownAware(response.content || "", 50, 200);
-
-    for (const chunk of chunks) {
-      await trigger("stream::send", {
-        stream_name: "chat",
-        group_id: sessionId || `default:${agentId || "default"}`,
-        data: {
-          type: "delta",
-          delta: chunk,
-          model: response.model,
-        },
-      }).catch(() => {});
-    }
-
-    await trigger("stream::send", {
-      stream_name: "chat",
-      group_id: sessionId || `default:${agentId || "default"}`,
-      data: {
-        type: "done",
-        content: response.content,
-        usage: response.usage,
-        model: response.model,
-      },
-    }).catch(() => {});
-
     return {
       status_code: 200,
       body: {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,22 +1,42 @@
 import { initSDK } from "./shared/config.js";
+import { metrics } from "@opentelemetry/api";
 
 const { registerFunction, registerTrigger } = initSDK("telemetry");
 
-registerFunction(
-  {
-    id: "telemetry::record",
-    description: "Record a metric event (delegates to OTel)",
-    metadata: { category: "telemetry" },
-  },
-  async (input: {
-    name: string;
-    value: number;
-    labels?: Record<string, string>;
-    type?: "counter" | "histogram" | "gauge";
-  }) => {
-    return { recorded: true, name: input.name, note: "Metrics collected via OTel" };
-  },
-);
+const meter = metrics.getMeter("agentos");
+
+let lastCpuUsage = process.cpuUsage();
+let lastCpuTime = Date.now();
+
+function collectWorkerMetrics() {
+  const mem = process.memoryUsage();
+  const currentCpu = process.cpuUsage(lastCpuUsage);
+  const elapsed = (Date.now() - lastCpuTime) * 1000;
+  const cpuPercent = elapsed > 0 ? ((currentCpu.user + currentCpu.system) / elapsed) * 100 : 0;
+  lastCpuUsage = process.cpuUsage();
+  lastCpuTime = Date.now();
+
+  return {
+    cpuPercent: Math.round(cpuPercent * 10) / 10,
+    memoryRss: mem.rss,
+    memoryHeapUsed: mem.heapUsed,
+    memoryHeapTotal: mem.heapTotal,
+    uptimeSeconds: process.uptime(),
+  };
+}
+
+meter.createObservableGauge("agentos.cpu.percent", {
+  description: "CPU usage percentage",
+}).addCallback((obs) => {
+  const m = collectWorkerMetrics();
+  obs.observe(m.cpuPercent);
+});
+
+meter.createObservableGauge("agentos.memory.rss", {
+  description: "Resident set size in bytes",
+}).addCallback((obs) => {
+  obs.observe(process.memoryUsage.rss());
+});
 
 registerFunction(
   {
@@ -25,12 +45,10 @@ registerFunction(
     metadata: { category: "telemetry" },
   },
   async () => {
+    const snapshot = collectWorkerMetrics();
     return {
-      counters: {},
-      histograms: {},
-      gauges: {},
+      ...snapshot,
       collectedAt: new Date().toISOString(),
-      note: "Metrics available via OTel exporter endpoint",
     };
   },
 );
@@ -42,9 +60,16 @@ registerFunction(
     metadata: { category: "telemetry" },
   },
   async () => {
+    const snapshot = collectWorkerMetrics();
+    const lines = [
+      `CPU Usage: ${snapshot.cpuPercent}%`,
+      `Memory RSS: ${(snapshot.memoryRss / 1024 / 1024).toFixed(1)} MB`,
+      `Heap Used: ${(snapshot.memoryHeapUsed / 1024 / 1024).toFixed(1)} MB`,
+      `Uptime: ${snapshot.uptimeSeconds.toFixed(0)} s`,
+    ];
     return {
-      text: "Metrics are now collected via OpenTelemetry.\nUse your OTel-compatible dashboard (Grafana, Jaeger, etc.) to view metrics.",
-      data: { note: "OTel auto-collects worker CPU, memory, event loop lag, and uptime" },
+      text: lines.join("\n"),
+      data: snapshot,
     };
   },
 );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,14 +11,13 @@ import { promisify } from "util";
 import { assertNoSsrf } from "./shared/utils.js";
 import { safeCall } from "./shared/errors.js";
 import { createLogger } from "./shared/logger.js";
-import { createRecordMetric } from "./shared/metrics.js";
+import { recordMetric } from "./shared/metrics.js";
 
 const log = createLogger("tools");
 const execFileAsync = promisify(execFile);
 
 const { registerFunction, registerTrigger, trigger, triggerVoid } = initSDK("tools");
 
-const recordMetric = createRecordMetric(triggerVoid);
 
 async function withToolMetrics<T>(
   toolId: string,


### PR DESCRIPTION
## Summary
- **Metrics**: Replace `createRecordMetric(triggerVoid)` factory with direct `@opentelemetry/api` meter instrumentation and lazy instrument caching
- **Telemetry**: Replace 3 stub functions with real `process.cpuUsage`/`memoryUsage`/`uptime` metrics + OTel observable gauges
- **Logger**: Simplify by removing redundant interfaces, inlining try/catch, using dynamic property access
- **Phantom calls**: Remove all `stream::send` calls from streaming, approval, and approval-tiers (function was never registered)
- **Consumer files**: Update agent-core, tools, memory to use direct `recordMetric` import instead of factory

## Test plan
- [x] All 1422 tests pass (48 test files)
- [x] No new TypeScript type errors introduced
- [x] Removed 2 stale tests that asserted phantom `stream::send` behavior
- [x] Updated approval test to verify `publish` instead of removed `stream::send`
- [x] Added `@opentelemetry/api` mock to agent-core tests

**12 files changed, -32 lines net**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features Removed**
  * Stream-based chat response chunking removed; responses now return directly without intermediate delta events.
  * Telemetry `record` function removed from public API.

* **Changes**
  * Telemetry reporting updated: `summary` and `dashboard` functions now provide live runtime metrics snapshots.
  * Approval workflow no longer emits stream notifications.
  * Logging and metrics infrastructure refactored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->