### PR TITLE
fix: remove direct @opentelemetry/api imports, use iii-sdk OTel

### DIFF
--- a/src/__tests__/agent-core.test.ts
+++ b/src/__tests__/agent-core.test.ts
@@ -84,18 +84,14 @@ vi.mock("iii-sdk", () => ({
     triggerVoid: mockTriggerVoid,
     listFunctions: mockListFunctions,
   }),
-  getContext: vi.fn(() => ({ logger: null })),
-}));
-
-const noopInstrument = { add: vi.fn(), record: vi.fn() };
-vi.mock("@opentelemetry/api", () => ({
-  metrics: {
-    getMeter: vi.fn(() => ({
-      createCounter: vi.fn(() => noopInstrument),
-      createHistogram: vi.fn(() => noopInstrument),
-      createUpDownCounter: vi.fn(() => noopInstrument),
-    })),
-  },
+  getContext: vi.fn(() => ({
+    logger: null,
+    meter: {
+      createCounter: vi.fn(() => ({ add: vi.fn() })),
+      createHistogram: vi.fn(() => ({ record: vi.fn() })),
+      createUpDownCounter: vi.fn(() => ({ add: vi.fn() })),
+    },
+  })),
 }));
 
 vi.mock("../shared/errors.js", () => ({

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,10 +1,16 @@
-import { metrics } from "@opentelemetry/api";
+import { getContext } from "iii-sdk";
 
 type MetricType = "counter" | "histogram" | "gauge";
 
-const meter = metrics.getMeter("agentos");
-
 const instrumentCache = new Map<string, any>();
+
+function getMeter() {
+  try {
+    return getContext().meter;
+  } catch {
+    return null;
+  }
+}
 
 function getOrCreate(name: string, factory: () => any): any {
   let instrument = instrumentCache.get(name);
@@ -22,6 +28,8 @@ export function recordMetric(
   type: MetricType = "counter",
 ): void {
   try {
+    const meter = getMeter();
+    if (!meter) return;
     if (type === "counter") {
       getOrCreate(name, () => meter.createCounter(name)).add(value, labels);
     } else if (type === "histogram") {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,53 +1,20 @@
 import { initSDK } from "./shared/config.js";
-import { metrics } from "@opentelemetry/api";
 
 const { registerFunction, registerTrigger } = initSDK("telemetry");
-
-const meter = metrics.getMeter("agentos");
-
-let lastCpuUsage = process.cpuUsage();
-let lastCpuTime = Date.now();
-
-function collectWorkerMetrics() {
-  const mem = process.memoryUsage();
-  const currentCpu = process.cpuUsage(lastCpuUsage);
-  const elapsed = (Date.now() - lastCpuTime) * 1000;
-  const cpuPercent = elapsed > 0 ? ((currentCpu.user + currentCpu.system) / elapsed) * 100 : 0;
-  lastCpuUsage = process.cpuUsage();
-  lastCpuTime = Date.now();
-
-  return {
-    cpuPercent: Math.round(cpuPercent * 10) / 10,
-    memoryRss: mem.rss,
-    memoryHeapUsed: mem.heapUsed,
-    memoryHeapTotal: mem.heapTotal,
-    uptimeSeconds: process.uptime(),
-  };
-}
-
-meter.createObservableGauge("agentos.cpu.percent", {
-  description: "CPU usage percentage",
-}).addCallback((obs) => {
-  const m = collectWorkerMetrics();
-  obs.observe(m.cpuPercent);
-});
-
-meter.createObservableGauge("agentos.memory.rss", {
-  description: "Resident set size in bytes",
-}).addCallback((obs) => {
-  obs.observe(process.memoryUsage.rss());
-});
 
 registerFunction(
   {
     id: "telemetry::summary",
-    description: "Return OTel metrics summary",
+    description: "Return worker metrics summary",
     metadata: { category: "telemetry" },
   },
   async () => {
-    const snapshot = collectWorkerMetrics();
+    const mem = process.memoryUsage();
     return {
-      ...snapshot,
+      memoryRss: mem.rss,
+      memoryHeapUsed: mem.heapUsed,
+      memoryHeapTotal: mem.heapTotal,
+      uptimeSeconds: process.uptime(),
       collectedAt: new Date().toISOString(),
     };
   },
@@ -56,21 +23,22 @@ registerFunction(
 registerFunction(
   {
     id: "telemetry::dashboard",
-    description: "Metrics dashboard (OTel-backed)",
+    description: "Metrics dashboard",
     metadata: { category: "telemetry" },
   },
   async () => {
-    const snapshot = collectWorkerMetrics();
-    const lines = [
-      `CPU Usage: ${snapshot.cpuPercent}%`,
-      `Memory RSS: ${(snapshot.memoryRss / 1024 / 1024).toFixed(1)} MB`,
-      `Heap Used: ${(snapshot.memoryHeapUsed / 1024 / 1024).toFixed(1)} MB`,
-      `Uptime: ${snapshot.uptimeSeconds.toFixed(0)} s`,
-    ];
-    return {
-      text: lines.join("\n"),
-      data: snapshot,
+    const mem = process.memoryUsage();
+    const data = {
+      memoryRss: mem.rss,
+      memoryHeapUsed: mem.heapUsed,
+      uptimeSeconds: process.uptime(),
     };
+    const lines = [
+      `Memory RSS: ${(data.memoryRss / 1024 / 1024).toFixed(1)} MB`,
+      `Heap Used: ${(data.memoryHeapUsed / 1024 / 1024).toFixed(1)} MB`,
+      `Uptime: ${data.uptimeSeconds.toFixed(0)} s`,
+    ];
+    return { text: lines.join("\n"), data };
   },
 );
 


### PR DESCRIPTION
## Summary

- **Remove all direct `@opentelemetry/api` imports** from `src/shared/metrics.ts` and `src/telemetry.ts` — the SDK provides OTel for free when `otel.enabled: true` is passed to `init()`
- **`src/shared/metrics.ts`**: now gets the meter via `getContext().meter` from iii-sdk instead of `metrics.getMeter()` from `@opentelemetry/api`
- **`src/telemetry.ts`**: removed 32 lines of manual observable gauge creation (`createObservableGauge` for CPU/memory), `collectWorkerMetrics()` function, and CPU tracking state — the SDK's `WorkerMetricsCollector` handles all of this automatically
- **Tests**: updated `getContext` mock to include `meter`; removed separate `@opentelemetry/api` mock

### Addresses Mike's feedback
| Concern | Resolution |
|---------|------------|
| "wrote a similar sdk over the top" | Removed all direct OTel imports; SDK provides OTel for free |
| "OTel should be automatic" | `initSDK()` passes `otel: { enabled: true }` — zero manual OTel setup |
| "recreating primitives with slight api changes" | No more custom metrics collection; SDK handles it |

## Test plan

- [x] All 1,422 tests pass (`npx vitest --run`)
- [x] Zero `@opentelemetry` imports remain in `src/` (`grep -r "@opentelemetry" src/` returns nothing)
- [x] `iii-sdk` is the sole OTel source (`getContext().meter` in metrics.ts, `init()` in config.ts)
- [ ] Verify OTel metrics still export correctly with a running iii engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified telemetry metrics collection to focus on memory usage and uptime reporting.
  * Removed CPU metrics from dashboard and summary endpoints.
  * Streamlined metrics initialization and collection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->