### PR TITLE
feat: branded SVG assets for README visual overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,31 @@
-# AgentOS
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/banner-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/banner-light.svg">
+    <img alt="AgentOS — The Agent Operating System" src="assets/banner-dark.svg" width="800">
+  </picture>
+</p>
 
-Agent Operating System built on three primitives: **Worker**, **Function**, **Trigger**.
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-facc15?style=for-the-badge" alt="License"></a>
+  <img src="https://img.shields.io/badge/Tests-2,727_passing-22c55e?style=for-the-badge" alt="Tests">
+  <img src="https://img.shields.io/badge/Tools-60+-facc15?style=for-the-badge" alt="Tools">
+  <img src="https://img.shields.io/badge/LLM_Providers-25-fde68a?style=for-the-badge" alt="LLM Providers">
+  <img src="https://img.shields.io/badge/Models-47-71717a?style=for-the-badge" alt="Models">
+</p>
 
-**60+ tools** · **2,727 tests** · **25 LLM providers** · **47 models** · **40 channels** · **65K LOC**
+<p align="center">
+  <a href="https://agentos.sh">Website</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#architecture">Architecture</a> ·
+  <a href="https://github.com/iii-hq/agentos">GitHub</a>
+</p>
 
 Every capability — agents, memory, security, LLM routing, workflows, tools, swarms, knowledge graphs, session replay, vault, **self-evolving functions**, **DAG-based artifact exchange**, **inter-agent coordination** — is a plain function registered on an [iii-engine](https://iii.dev) bus. No frameworks, no vendor lock-in, no magic.
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                        iii-engine                            │
-│              Worker · Function · Trigger                     │
-├──────────┬───────────┬───────────┬───────────┬───────────────┤
-│ agent    │ security  │    llm    │  memory   │     wasm      │
-│ core     │  rbac     │  router   │  store    │    sandbox    │
-│ workflow │  audit    │ 25 LLMs   │  session  │   (wasmtime)  │
-│ api      │  taint    │  catalog  │  recall   │    (Rust)     │
-│ hand     │  sign     │   (Rust)  │  (Rust)   │               │
-│ (Rust)   │  (Rust)   │           │           │               │
-├──────────┴───────────┴───────────┴───────────┴───────────────┤
-│                   Control Plane (Rust)                       │
-│  realm · hierarchy · directive · mission · ledger            │
-│  council · pulse · bridge (8 crates, 45 functions)           │
-├──────────────────────────────────────────────────────────────┤
-│             Evolve / Eval / Feedback Loop                    │
-│  evolve (LLM code gen + vm sandbox + DAG branching)          │
-│  eval (pluggable scorers + suites + inline auto-scoring)     │
-│  feedback (review + improve + promote/kill + leaderboard)    │
-│                      (TypeScript)                            │
-├──────────────────────────────────────────────────────────────┤
-│  artifact-dag (DAG content exchange + diff + frontier)       │
-│  coordination (channels + threaded posts + pinning)          │
-│                      (TypeScript)                            │
-├──────────────────────────────────────────────────────────────┤
-│  api · workflows · tools(60+) · skills · channels · hooks    │
-│  approval · streaming · mcp · a2a · vault · browser · swarm  │
-│  knowledge-graph · session-replay · skillkit · tool-profiles │
-│                      (TypeScript)                            │
-├──────────────────────────────────────────────────────────────┤
-│                    embedding (Python)                        │
-├──────────────────────────────────────────────────────────────┤
-│     CLI (Rust)              TUI (Rust/ratatui)               │
-├──────────────────────────────────────────────────────────────┤
-│ 45 agents · 7 hands · 25 integrations · 40 channels          │
-│ 8 tool profiles · 47 models · 21 TUI screens                 │
-└──────────────────────────────────────────────────────────────┘
-```
+<p align="center">
+  <img src="assets/architecture.svg" alt="AgentOS architecture: Rust (18 crates), TypeScript (46 workers), Python (embeddings) on iii-engine" width="720">
+</p>
 
 ## Install
 

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,0 +1,158 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 460" width="720" height="460">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#facc15" stop-opacity="0.04"/>
+      <stop offset="100%" stop-color="#facc15" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="720" height="460" rx="12" fill="#0a0a0a"/>
+  <rect width="720" height="460" rx="12" fill="url(#glow)"/>
+  <rect x="0.5" y="0.5" width="719" height="459" rx="12" fill="none" stroke="#ffffff" stroke-opacity="0.06"/>
+
+  <!-- Title -->
+  <text x="360" y="32" text-anchor="middle" font-family="'Courier New',monospace" font-size="11" fill="#71717a" letter-spacing="1" text-transform="uppercase">ARCHITECTURE</text>
+
+  <!-- Rust Layer -->
+  <rect x="24" y="48" width="672" height="120" rx="8" fill="#facc15" fill-opacity="0.03" stroke="#facc15" stroke-opacity="0.2" stroke-width="1"/>
+  <text x="40" y="72" font-family="'Courier New',monospace" font-size="13" font-weight="700" fill="#facc15">Rust</text>
+  <rect x="80" y="60" width="72" height="20" rx="10" fill="#facc15" fill-opacity="0.08"/>
+  <text x="116" y="74" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#71717a">18 crates</text>
+
+  <!-- Rust pills row 1 -->
+  <g transform="translate(40, 86)">
+    <rect x="0" y="0" width="44" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="22" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">cli</text>
+
+    <rect x="52" y="0" width="44" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="74" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">tui</text>
+
+    <rect x="104" y="0" width="78" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="143" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">security</text>
+
+    <rect x="190" y="0" width="66" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="223" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">memory</text>
+
+    <rect x="264" y="0" width="94" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="311" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">llm-router</text>
+
+    <rect x="366" y="0" width="112" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="422" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">wasm-sandbox</text>
+
+    <rect x="486" y="0" width="60" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="516" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">realm</text>
+  </g>
+
+  <!-- Rust pills row 2 -->
+  <g transform="translate(40, 118)">
+    <rect x="0" y="0" width="86" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="43" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">hierarchy</text>
+
+    <rect x="94" y="0" width="86" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="137" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">directive</text>
+
+    <rect x="188" y="0" width="72" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="224" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">mission</text>
+
+    <rect x="268" y="0" width="66" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="301" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">ledger</text>
+
+    <rect x="342" y="0" width="72" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="378" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">council</text>
+
+    <rect x="422" y="0" width="60" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="452" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">pulse</text>
+
+    <rect x="490" y="0" width="66" height="24" rx="4" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.12"/>
+    <text x="523" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#fde68a">bridge</text>
+  </g>
+
+  <!-- Connector -->
+  <line x1="360" y1="168" x2="360" y2="180" stroke="#ffffff" stroke-opacity="0.1" stroke-width="1"/>
+
+  <!-- TypeScript Layer -->
+  <rect x="24" y="180" width="672" height="152" rx="8" fill="#ffffff" fill-opacity="0.015" stroke="#ffffff" stroke-opacity="0.06" stroke-width="1"/>
+  <text x="40" y="204" font-family="'Courier New',monospace" font-size="13" font-weight="700" fill="#e4e4e7">TypeScript</text>
+  <rect x="120" y="192" width="86" height="20" rx="10" fill="#ffffff" fill-opacity="0.04"/>
+  <text x="163" y="206" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#71717a">46 workers</text>
+
+  <!-- TS pills row 1 -->
+  <g transform="translate(40, 218)">
+    <rect x="0" y="0" width="94" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="47" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">agent-core</text>
+
+    <rect x="102" y="0" width="54" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="129" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">tools</text>
+
+    <rect x="164" y="0" width="82" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="205" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">channels</text>
+
+    <rect x="254" y="0" width="44" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="276" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">api</text>
+
+    <rect x="306" y="0" width="66" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="339" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">evolve</text>
+
+    <rect x="380" y="0" width="52" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="406" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">eval</text>
+
+    <rect x="440" y="0" width="78" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="479" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">feedback</text>
+  </g>
+
+  <!-- TS pills row 2 -->
+  <g transform="translate(40, 250)">
+    <rect x="0" y="0" width="112" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="56" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">artifact-dag</text>
+
+    <rect x="120" y="0" width="112" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="176" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">coordination</text>
+
+    <rect x="240" y="0" width="60" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="270" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">swarm</text>
+
+    <rect x="308" y="0" width="130" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="373" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">knowledge-graph</text>
+
+    <rect x="446" y="0" width="60" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="476" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">vault</text>
+  </g>
+
+  <!-- TS pills row 3 -->
+  <g transform="translate(40, 282)">
+    <rect x="0" y="0" width="82" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="41" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">security</text>
+
+    <rect x="90" y="0" width="82" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="131" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">approval</text>
+
+    <rect x="180" y="0" width="86" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="223" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">streaming</text>
+
+    <rect x="274" y="0" width="44" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="296" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">mcp</text>
+
+    <rect x="326" y="0" width="44" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="348" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">a2a</text>
+
+    <rect x="378" y="0" width="78" height="24" rx="4" fill="#ffffff" fill-opacity="0.03" stroke="#ffffff" stroke-opacity="0.06"/>
+    <text x="417" y="16" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#a1a1aa">+25 more</text>
+  </g>
+
+  <!-- Connector -->
+  <line x1="360" y1="332" x2="360" y2="344" stroke="#ffffff" stroke-opacity="0.1" stroke-width="1"/>
+
+  <!-- Python Layer -->
+  <rect x="24" y="344" width="672" height="44" rx="8" fill="#ffffff" fill-opacity="0.015" stroke="#ffffff" stroke-opacity="0.06" stroke-width="1"/>
+  <text x="40" y="372" font-family="'Courier New',monospace" font-size="13" font-weight="700" fill="#e4e4e7">Python</text>
+  <rect x="104" y="358" width="86" height="20" rx="10" fill="#ffffff" fill-opacity="0.04"/>
+  <text x="147" y="372" text-anchor="middle" font-family="'Courier New',monospace" font-size="10" fill="#71717a">embeddings</text>
+
+  <!-- Connector -->
+  <line x1="360" y1="388" x2="360" y2="400" stroke="#facc15" stroke-opacity="0.3" stroke-width="1"/>
+
+  <!-- iii-engine foundation -->
+  <rect x="24" y="400" width="672" height="44" rx="8" fill="#facc15" fill-opacity="0.06" stroke="#facc15" stroke-opacity="0.25" stroke-width="1"/>
+  <text x="360" y="428" text-anchor="middle" font-family="'Courier New',monospace" font-size="13" font-weight="700" fill="#facc15">iii-engine</text>
+  <text x="460" y="428" font-family="'Courier New',monospace" font-size="11" fill="#71717a">Worker / Function / Trigger</text>
+</svg>

--- a/assets/banner-dark.svg
+++ b/assets/banner-dark.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 180" width="800" height="180">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#facc15" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#facc15" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="180" rx="12" fill="#0a0a0a"/>
+  <rect width="800" height="180" rx="12" fill="url(#glow)"/>
+  <rect x="0.5" y="0.5" width="799" height="179" rx="12" fill="none" stroke="#ffffff" stroke-opacity="0.06"/>
+
+  <g transform="translate(346, 24)">
+    <rect width="40" height="40" rx="6" fill="#000"/>
+    <rect x="1.5" y="1.5" width="37" height="37" rx="5" fill="none" stroke="#facc15" stroke-width="1.5"/>
+    <path d="M12.5 28L20 14L27.5 28" stroke="#facc15" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <line x1="15.5" y1="23.5" x2="24.5" y2="23.5" stroke="#facc15" stroke-width="2" stroke-linecap="round"/>
+  </g>
+
+  <g transform="translate(396, 30)">
+    <text x="0" y="28" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="32" font-weight="800" letter-spacing="-1">
+      <tspan fill="#ffffff">Agent</tspan><tspan fill="#facc15">OS</tspan>
+    </text>
+  </g>
+
+  <text x="400" y="92" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="14" fill="#71717a">
+    The Agent Operating System
+  </text>
+
+  <g transform="translate(400, 115)" text-anchor="middle">
+    <text x="0" y="0" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="12" fill="#a1a1aa">
+      Built on three primitives:
+    </text>
+    <g transform="translate(0, 24)">
+      <rect x="-160" y="-14" width="90" height="24" rx="12" fill="#facc15" fill-opacity="0.1" stroke="#facc15" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="-115" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#facc15">Worker</text>
+
+      <rect x="-52" y="-14" width="104" height="24" rx="12" fill="#facc15" fill-opacity="0.1" stroke="#facc15" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="0" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#facc15">Function</text>
+
+      <rect x="70" y="-14" width="90" height="24" rx="12" fill="#facc15" fill-opacity="0.1" stroke="#facc15" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="115" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#facc15">Trigger</text>
+    </g>
+  </g>
+</svg>

--- a/assets/banner-light.svg
+++ b/assets/banner-light.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 180" width="800" height="180">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#eab308" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#eab308" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="800" height="180" rx="12" fill="#ffffff"/>
+  <rect width="800" height="180" rx="12" fill="url(#glow)"/>
+  <rect x="0.5" y="0.5" width="799" height="179" rx="12" fill="none" stroke="#000000" stroke-opacity="0.08"/>
+
+  <g transform="translate(346, 24)">
+    <rect width="40" height="40" rx="6" fill="#000"/>
+    <rect x="1.5" y="1.5" width="37" height="37" rx="5" fill="none" stroke="#facc15" stroke-width="1.5"/>
+    <path d="M12.5 28L20 14L27.5 28" stroke="#facc15" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <line x1="15.5" y1="23.5" x2="24.5" y2="23.5" stroke="#facc15" stroke-width="2" stroke-linecap="round"/>
+  </g>
+
+  <g transform="translate(396, 30)">
+    <text x="0" y="28" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="32" font-weight="800" letter-spacing="-1">
+      <tspan fill="#1a1a1a">Agent</tspan><tspan fill="#eab308">OS</tspan>
+    </text>
+  </g>
+
+  <text x="400" y="92" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="14" fill="#71717a">
+    The Agent Operating System
+  </text>
+
+  <g transform="translate(400, 115)" text-anchor="middle">
+    <text x="0" y="0" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="12" fill="#71717a">
+      Built on three primitives:
+    </text>
+    <g transform="translate(0, 24)">
+      <rect x="-160" y="-14" width="90" height="24" rx="12" fill="#eab308" fill-opacity="0.08" stroke="#eab308" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="-115" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#eab308">Worker</text>
+
+      <rect x="-52" y="-14" width="104" height="24" rx="12" fill="#eab308" fill-opacity="0.08" stroke="#eab308" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="0" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#eab308">Function</text>
+
+      <rect x="70" y="-14" width="90" height="24" rx="12" fill="#eab308" fill-opacity="0.08" stroke="#eab308" stroke-opacity="0.2" stroke-width="1"/>
+      <text x="115" y="2" text-anchor="middle" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="11" font-weight="600" fill="#eab308">Trigger</text>
+    </g>
+  </g>
+</svg>

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 48" width="320" height="48">
+  <g transform="translate(0, 4)">
+    <rect width="40" height="40" rx="6" fill="#000"/>
+    <rect x="1.5" y="1.5" width="37" height="37" rx="5" fill="none" stroke="#facc15" stroke-width="1.5"/>
+    <path d="M12.5 28L20 14L27.5 28" stroke="#facc15" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <line x1="15.5" y1="23.5" x2="24.5" y2="23.5" stroke="#facc15" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="52" y="33" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="32" font-weight="800" letter-spacing="-1">
+    <tspan fill="#ffffff">Agent</tspan><tspan fill="#facc15">OS</tspan>
+  </text>
+</svg>

--- a/assets/logo-light.svg
+++ b/assets/logo-light.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 48" width="320" height="48">
+  <g transform="translate(0, 4)">
+    <rect width="40" height="40" rx="6" fill="#000"/>
+    <rect x="1.5" y="1.5" width="37" height="37" rx="5" fill="none" stroke="#facc15" stroke-width="1.5"/>
+    <path d="M12.5 28L20 14L27.5 28" stroke="#facc15" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <line x1="15.5" y1="23.5" x2="24.5" y2="23.5" stroke="#facc15" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="52" y="33" font-family="'SF Mono','Cascadia Code','Fira Code','JetBrains Mono','Consolas','Courier New',monospace" font-size="32" font-weight="800" letter-spacing="-1">
+    <tspan fill="#1a1a1a">Agent</tspan><tspan fill="#eab308">OS</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary

- Replace plain-text ASCII architecture box with professional SVG assets matching [agentos.sh](https://agentos.sh) branding
- Add theme-aware banner (dark/light mode via `<picture>` tag)
- Add theme-aware logo SVGs with favicon mark + AgentOS wordmark
- Add layered architecture diagram (Rust → TypeScript → Python → iii-engine)
- Add `for-the-badge` shields.io badges (license, tests, tools, LLMs, models)
- Add navigation links row

## Assets Created

| File | Size | Purpose |
|------|------|---------|
| `assets/banner-dark.svg` | 2.9KB | Hero banner (dark mode) |
| `assets/banner-light.svg` | 2.9KB | Hero banner (light mode) |
| `assets/logo-dark.svg` | 799B | Logo for dark backgrounds |
| `assets/logo-light.svg` | 799B | Logo for light backgrounds |
| `assets/architecture.svg` | 12KB | Layered architecture diagram |

**Total**: 19KB — lightweight, no external dependencies.

## Branding

All colors from `agentos.sh`: `#facc15` primary yellow, `#0a0a0a` surface, `#71717a` muted. Favicon triangle mark reused from website. Monospace font stack with system fallbacks for GitHub SVG rendering.

## Before / After

**Before**: Plain markdown `#` header + ASCII art box
**After**: Theme-aware SVG banner + for-the-badge badges + SVG architecture diagram

## Test plan

- [ ] Verify banner renders in GitHub dark mode
- [ ] Verify banner renders in GitHub light mode
- [ ] Verify architecture SVG renders correctly
- [ ] Verify badges load from shields.io
- [ ] Check mobile rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved architecture documentation with enhanced visual representation of system components and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->