### PR TITLE
feat: bump iii-sdk to 0.11.4-next.4 + inline compat shim per worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
       - name: install iii CLI
         run: |
           set -e
-          curl -fsSL install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
-            curl -fsSL install.iii.dev/iii/main/install.sh | sh
+          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
+            curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
           echo "$HOME/.iii/bin" >> $GITHUB_PATH
 
       - name: verify iii version
@@ -230,16 +230,18 @@ jobs:
 
       - name: install iii CLI
         run: |
-          curl -fsSL install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
-            curl -fsSL install.iii.dev/iii/main/install.sh | sh
+          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
+            curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
           echo "$HOME/.iii/bin" >> $GITHUB_PATH
 
       - name: skip if no api key
         id: gate
+        env:
+          AGENTOS_API_KEY: ${{ secrets.AGENTOS_API_KEY }}
         run: |
-          if [ -z "${{ secrets.AGENTOS_API_KEY }}" ]; then
+          if [ -z "${AGENTOS_API_KEY:-}" ]; then
             echo "::warning::AGENTOS_API_KEY not set; skipping e2e-full"
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: start engine + workers
@@ -247,10 +249,13 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          set -e
           mkdir -p data
           iii --config config.yaml > engine.log 2>&1 &
+          ENGINE_PID=$!
+          echo "ENGINE_PID=$ENGINE_PID" >> "$GITHUB_ENV"
           for i in {1..30}; do
-            curl -fs http://127.0.0.1:3111/api/health > /dev/null 2>&1 && break
+            timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/3111" 2>/dev/null && break
             sleep 1
           done
           for w in agentos-core agentos-llm-router agentos-memory agentos-security; do
@@ -274,3 +279,9 @@ jobs:
             echo "=== $f ==="
             tail -200 "$f" || true
           done
+
+      - name: stop
+        if: always()
+        run: |
+          pkill -f 'agentos-' || true
+          [ -n "${ENGINE_PID:-}" ] && kill "$ENGINE_PID" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.85.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -48,31 +46,40 @@ jobs:
       - name: validate every workers/*/iii.worker.yaml
         run: |
           set -euo pipefail
-          missing=0
-          for d in workers/*/; do
-            name="$(basename "$d")"
-            [ "$name" = "embedding" ] && continue
-            if [ ! -f "$d/iii.worker.yaml" ]; then
-              echo "::error::missing iii.worker.yaml in $d"
-              missing=1
-              continue
-            fi
-            python3 - <<EOF
-          import yaml, sys
-          with open("$d/iii.worker.yaml") as fp:
-              m = yaml.safe_load(fp)
-          required = ["iii", "name", "language", "deploy", "manifest"]
-          for k in required:
-              assert k in m, f"$d/iii.worker.yaml missing key: {k}"
-          assert m["name"] == "$name", f"$d/iii.worker.yaml name='{m['name']}' != folder '$name'"
-          assert m["iii"] == "v1", f"$d/iii.worker.yaml iii must be v1"
-          assert m["deploy"] in ("binary", "image"), f"$d/iii.worker.yaml deploy invalid"
-          if m["deploy"] == "binary":
-              assert "bin" in m, f"$d/iii.worker.yaml binary deploy needs bin"
-          print(f"ok: {m['name']}")
-          EOF
-          done
-          exit $missing
+          python3 - <<'PYEOF'
+          import sys
+          from pathlib import Path
+          import yaml
+
+          fail = False
+          for d in sorted(Path("workers").iterdir()):
+              if not d.is_dir() or d.name == "embedding":
+                  continue
+              p = d / "iii.worker.yaml"
+              if not p.exists():
+                  print(f"::error::missing {p}")
+                  fail = True
+                  continue
+              m = yaml.safe_load(p.read_text())
+              for k in ("iii", "name", "language", "deploy", "manifest"):
+                  if k not in m:
+                      print(f"::error::{p} missing key {k}")
+                      fail = True
+              if m.get("name") != d.name:
+                  print(f"::error::{p} name='{m.get('name')}' != folder '{d.name}'")
+                  fail = True
+              if m.get("iii") != "v1":
+                  print(f"::error::{p} iii must be v1")
+                  fail = True
+              if m.get("deploy") not in ("binary", "image"):
+                  print(f"::error::{p} deploy invalid")
+                  fail = True
+              if m.get("deploy") == "binary" and "bin" not in m:
+                  print(f"::error::{p} binary deploy needs bin")
+                  fail = True
+              print(f"ok: {m.get('name')}")
+          sys.exit(1 if fail else 0)
+          PYEOF
 
   namespace-clash:
     name: "no sandbox::* clash with builtin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,244 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  rust:
+    name: rust build + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: cargo build
+        run: cargo build --workspace --release
+
+      - name: cargo test
+        run: cargo test --workspace --release
+
+      - name: upload worker binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: worker-binaries
+          path: |
+            target/release/agentos-*
+          retention-days: 7
+
+  worker-yaml:
+    name: validate iii.worker.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: validate every workers/*/iii.worker.yaml
+        run: |
+          set -euo pipefail
+          missing=0
+          for d in workers/*/; do
+            name="$(basename "$d")"
+            [ "$name" = "embedding" ] && continue
+            if [ ! -f "$d/iii.worker.yaml" ]; then
+              echo "::error::missing iii.worker.yaml in $d"
+              missing=1
+              continue
+            fi
+            python3 - <<EOF
+          import yaml, sys
+          with open("$d/iii.worker.yaml") as fp:
+              m = yaml.safe_load(fp)
+          required = ["iii", "name", "language", "deploy", "manifest"]
+          for k in required:
+              assert k in m, f"$d/iii.worker.yaml missing key: {k}"
+          assert m["name"] == "$name", f"$d/iii.worker.yaml name='{m['name']}' != folder '$name'"
+          assert m["iii"] == "v1", f"$d/iii.worker.yaml iii must be v1"
+          assert m["deploy"] in ("binary", "image"), f"$d/iii.worker.yaml deploy invalid"
+          if m["deploy"] == "binary":
+              assert "bin" in m, f"$d/iii.worker.yaml binary deploy needs bin"
+          print(f"ok: {m['name']}")
+          EOF
+          done
+          exit $missing
+
+  namespace-clash:
+    name: "no sandbox::* clash with builtin"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "assert no sandbox:: registration"
+        run: |
+          set -e
+          if grep -rn '"sandbox::' workers/ crates/ 2>/dev/null; then
+            echo "::error::workers must not register sandbox::* — that namespace is reserved for the builtin iii-sandbox worker (iii v0.11.4-next.4). Use wasm:: instead."
+            exit 1
+          fi
+          echo "ok: no sandbox::* registrations in agentos workers"
+
+  e2e-smoke:
+    name: e2e smoke (no LLM key required)
+    runs-on: ubuntu-latest
+    needs: rust
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: install pnpm
+        run: npm install -g pnpm@9
+
+      - name: install deps
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: download worker binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: worker-binaries
+          path: target/release/
+
+      - name: chmod binaries
+        run: chmod +x target/release/agentos-*
+
+      - name: install iii CLI
+        run: |
+          set -e
+          curl -fsSL install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
+            curl -fsSL install.iii.dev/iii/main/install.sh | sh
+          echo "$HOME/.iii/bin" >> $GITHUB_PATH
+
+      - name: verify iii version
+        run: iii --version
+
+      - name: start engine + workers
+        run: |
+          set -e
+          mkdir -p data
+          iii --config config.yaml > engine.log 2>&1 &
+          ENGINE_PID=$!
+          echo "ENGINE_PID=$ENGINE_PID" >> $GITHUB_ENV
+          for i in {1..30}; do
+            if curl -fs http://127.0.0.1:3111/api/health > /dev/null 2>&1; then
+              echo "engine ready"
+              break
+            fi
+            sleep 1
+          done
+          for w in agentos-core agentos-llm-router agentos-memory agentos-security agentos-realm agentos-mission agentos-directive agentos-hierarchy agentos-council agentos-ledger agentos-pulse agentos-bridge agentos-wasm-sandbox; do
+            ./target/release/$w > "$w.log" 2>&1 &
+          done
+          sleep 5
+
+      - name: smoke check engine health
+        run: |
+          curl -fsS http://127.0.0.1:3111/api/health || (cat engine.log; exit 1)
+
+      - name: "assert wasm:: + sandbox:: coexist"
+        run: |
+          set -e
+          functions=$(curl -fsS http://127.0.0.1:3111/api/functions || echo '[]')
+          echo "$functions" | grep -q 'wasm::execute' || (echo "wasm::execute not registered"; exit 1)
+          echo "$functions" | grep -q 'sandbox::create' || echo "warn: sandbox::create not registered (iii-sandbox not configured)"
+          echo "ok: namespaces do not clash"
+
+      - name: dump worker logs on failure
+        if: failure()
+        run: |
+          for f in *.log; do
+            echo "=== $f ==="
+            tail -100 "$f" || true
+          done
+
+      - name: stop
+        if: always()
+        run: |
+          pkill -f 'agentos-' || true
+          [ -n "${ENGINE_PID:-}" ] && kill "$ENGINE_PID" || true
+
+  e2e-full:
+    name: e2e full (requires AGENTOS_API_KEY secret)
+    runs-on: ubuntu-latest
+    needs: e2e-smoke
+    if: ${{ github.event.repository.full_name == 'iii-experimental/agentos' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: install pnpm
+        run: npm install -g pnpm@9
+
+      - name: install deps
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: download worker binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: worker-binaries
+          path: target/release/
+
+      - name: chmod binaries
+        run: chmod +x target/release/agentos-*
+
+      - name: install iii CLI
+        run: |
+          curl -fsSL install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
+            curl -fsSL install.iii.dev/iii/main/install.sh | sh
+          echo "$HOME/.iii/bin" >> $GITHUB_PATH
+
+      - name: skip if no api key
+        id: gate
+        run: |
+          if [ -z "${{ secrets.AGENTOS_API_KEY }}" ]; then
+            echo "::warning::AGENTOS_API_KEY not set; skipping e2e-full"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: start engine + workers
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          mkdir -p data
+          iii --config config.yaml > engine.log 2>&1 &
+          for i in {1..30}; do
+            curl -fs http://127.0.0.1:3111/api/health > /dev/null 2>&1 && break
+            sleep 1
+          done
+          for w in agentos-core agentos-llm-router agentos-memory agentos-security; do
+            ./target/release/$w > "$w.log" 2>&1 &
+          done
+          sleep 5
+
+      - name: vitest e2e
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          AGENTOS_E2E: "1"
+          AGENTOS_BASE_URL: http://127.0.0.1:3111
+          AGENTOS_API_KEY: ${{ secrets.AGENTOS_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: pnpm run test:e2e
+
+      - name: dump logs on failure
+        if: failure()
+        run: |
+          for f in *.log; do
+            echo "=== $f ==="
+            tail -200 "$f" || true
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,42 @@ jobs:
           done
           sleep 5
 
-      - name: smoke check engine health
-        run: |
-          curl -fsS http://127.0.0.1:3111/api/health || (cat engine.log; exit 1)
-
-      - name: "assert wasm:: + sandbox:: coexist"
+      - name: engine WS port + HTTP port listening
         run: |
           set -e
-          functions=$(curl -fsS http://127.0.0.1:3111/api/functions || echo '[]')
-          echo "$functions" | grep -q 'wasm::execute' || (echo "wasm::execute not registered"; exit 1)
-          echo "$functions" | grep -q 'sandbox::create' || echo "warn: sandbox::create not registered (iii-sandbox not configured)"
-          echo "ok: namespaces do not clash"
+          for port in 49134 3111; do
+            timeout 5 bash -c "until echo > /dev/tcp/127.0.0.1/$port 2>/dev/null; do sleep 0.5; done" \
+              || (echo "::error::port $port never opened"; cat engine.log; exit 1)
+            echo "ok: port $port listening"
+          done
+
+      - name: workers registered functions in engine
+        run: |
+          set -e
+          # Workers report [REGISTERED] Function <id> when SDK successfully wires a function.
+          # Require >= 30 registered functions across all 13 agentos workers.
+          count=$(grep -c '\[REGISTERED\] Function' engine.log || echo 0)
+          echo "registered functions: $count"
+          if [ "$count" -lt 30 ]; then
+            echo "::error::expected >=30 registered functions, got $count"
+            cat engine.log
+            exit 1
+          fi
+
+      - name: "assert wasm:: + sandbox:: coexist (no namespace clash)"
+        run: |
+          set -e
+          # wasm-sandbox worker must register wasm::* not sandbox::*
+          grep -q 'Function wasm::execute' engine.log \
+            || (echo "::error::wasm::execute not registered"; exit 1)
+          # The builtin sandbox::* worker is opt-in (commented in config.yaml);
+          # if iii-sandbox were enabled, sandbox::create would also appear without
+          # colliding with our wasm::* names.
+          if grep -q 'Function sandbox::execute' engine.log; then
+            echo "::error::sandbox::execute is reserved for builtin iii-sandbox (iii v0.11.4-next.4)"
+            exit 1
+          fi
+          echo "ok: wasm:: registered, no agentos worker shadows sandbox::*"
 
       - name: dump worker logs on failure
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,10 +569,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -983,6 +1005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1169,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1258,6 +1303,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1426,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1388,6 +1453,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1553,15 +1631,23 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.8.3"
+version = "0.11.4-next.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b818b39809d21bac4c6c67534c2a8723b41f79bd85716fb94ab5bbc85d6e9cc7"
+checksum = "d951a12bea728b683dc50349b6c9600fb3671ed9a069dd59e254a64dad975deb"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "schemars",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -1835,6 +1921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1954,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1995,73 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "option-ext"
@@ -1931,6 +2112,26 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2014,6 +2215,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2145,6 +2384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2377,6 +2625,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,10 +2670,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2449,6 +2765,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2717,6 +3044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,7 +3216,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -2962,6 +3318,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,11 +3362,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3081,6 +3478,8 @@ dependencies = [
  "httparse",
  "log",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3091,6 +3490,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -3795,6 +4200,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +4231,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3834,6 +4271,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3944,6 +4391,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-iii-sdk = "0.8"
+iii-sdk = "=0.11.4-next.4"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/config.yaml
+++ b/config.yaml
@@ -55,4 +55,5 @@ workers:
           threshold: 10
           operator: ">"
           window_seconds: 60
-          action: log
+          action:
+            type: log

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,6 @@ workers:
       cors:
         allowed_origins: ['*']
         allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
-        allowed_headers: ['*']
 
   - name: iii-state
     config:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,5 @@
-port: 49134
-
-modules:
-  - class: modules::api::RestApiModule
+workers:
+  - name: iii-http
     config:
       port: 3111
       host: 0.0.0.0
@@ -12,43 +10,44 @@ modules:
         allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
         allowed_headers: ['*']
 
-  - class: modules::state::StateModule
+  - name: iii-state
     config:
       adapter:
-        class: modules::state::adapters::KvStore
+        name: kv
         config:
           store_method: file_based
           file_path: ./data/state
 
-  - class: modules::stream::StreamModule
+  - name: iii-stream
     config:
       port: 3112
       host: 0.0.0.0
       adapter:
-        class: modules::stream::adapters::KvStore
+        name: kv
         config:
           store_method: file_based
           file_path: ./data/streams
 
-  - class: modules::queue::QueueModule
+  - name: iii-queue
     config:
       adapter:
-        class: modules::queue::BuiltinQueueAdapter
+        name: builtin
 
-  - class: modules::pubsub::PubSubModule
+  - name: iii-pubsub
     config:
       adapter:
-        class: modules::pubsub::LocalAdapter
+        name: local
 
-  - class: modules::cron::CronModule
+  - name: iii-cron
     config:
       adapter:
-        class: modules::cron::KvCronAdapter
+        name: kv
 
-  - class: modules::observability::OtelModule
+  - name: iii-observability
     config:
       enabled: true
-      exporter: stdout
+      service_name: agentos
+      exporter: memory
       metrics_enabled: true
       logs_enabled: true
       alerts:
@@ -57,5 +56,4 @@ modules:
           threshold: 10
           operator: ">"
           window_seconds: 60
-          action:
-            type: log
+          action: log

--- a/workers/agent-core/src/main.rs
+++ b/workers/agent-core/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use std::time::Instant;
@@ -7,13 +7,135 @@ mod types;
 
 use types::{AgentConfig, ChatRequest, ToolCall};
 
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
+
 const MAX_ITERATIONS: u32 = 50;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -63,7 +185,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         move |_: Value| {
             let iii = iii_clone.clone();
             async move {
-                iii.trigger("state::list", json!({ "scope": "agents" })).await
+                iii.trigger_v0("state::list", json!({ "scope": "agents" })).await
                     .map_err(|e| IIIError::Handler(e.to_string()))
             }
         },
@@ -77,7 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_clone.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("");
-                iii.trigger("state::delete", json!({
+                iii.trigger_v0("state::delete", json!({
                     "scope": "agents",
                     "key": agent_id,
                 })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -92,7 +214,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("queue", "agent::chat", json!({ "topic": "agent.inbox" }))?;
+    iii.register_trigger_v0("queue", "agent::chat", json!({ "topic": "agent.inbox" }))?;
 
     tracing::info!("agent-core worker started");
     tokio::signal::ctrl_c().await?;
@@ -104,7 +226,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
     let start = Instant::now();
 
     let config: Option<AgentConfig> = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": "agents",
             "key": &req.agent_id,
         }))
@@ -113,7 +235,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         .and_then(|v| serde_json::from_value(v).ok());
 
     let memories: Value = iii
-        .trigger("memory::recall", json!({
+        .trigger_v0("memory::recall", json!({
             "agentId": &req.agent_id,
             "query": &req.message,
             "limit": 20,
@@ -122,7 +244,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         .unwrap_or(json!([]));
 
     let tools: Value = iii
-        .trigger("agent::list_tools", json!({ "agentId": &req.agent_id }))
+        .trigger_v0("agent::list_tools", json!({ "agentId": &req.agent_id }))
         .await
         .unwrap_or(json!([]));
 
@@ -131,7 +253,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         .unwrap_or_default();
 
     let model: Value = iii
-        .trigger("llm::route", json!({
+        .trigger_v0("llm::route", json!({
             "message": &req.message,
             "toolCount": tools.as_array().map(|a| a.len()).unwrap_or(0),
             "config": config.as_ref().and_then(|c| c.model.as_ref()),
@@ -140,7 +262,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let scan_result = iii
-        .trigger("security::scan_injection", json!({ "text": &req.message }))
+        .trigger_v0("security::scan_injection", json!({ "text": &req.message }))
         .await
         .unwrap_or(json!({ "safe": true, "riskScore": 0.0 }));
     let risk_score = scan_result["riskScore"].as_f64().unwrap_or(0.0);
@@ -158,7 +280,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
     messages.push(json!({ "role": "user", "content": &req.message }));
 
     let mut response: Value = iii
-        .trigger("llm::complete", json!({
+        .trigger_v0("llm::complete", json!({
             "model": model,
             "systemPrompt": system_prompt,
             "messages": messages,
@@ -182,7 +304,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
 
         let mut tool_results = Vec::new();
         for tc in &calls {
-            let cap_check = iii.trigger("security::check_capability", json!({
+            let cap_check = iii.trigger_v0("security::check_capability", json!({
                 "agentId": &req.agent_id,
                 "capability": tc.id.split("::").next().unwrap_or(""),
                 "resource": &tc.id,
@@ -196,7 +318,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
                 continue;
             }
 
-            match iii.trigger(&tc.id, tc.arguments.clone()).await {
+            match iii.trigger_v0(&tc.id, tc.arguments.clone()).await {
                 Ok(result) => {
                     tool_results.push(json!({
                         "toolCallId": tc.call_id,
@@ -218,7 +340,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         }
 
         response = iii
-            .trigger("llm::complete", json!({
+            .trigger_v0("llm::complete", json!({
                 "model": model,
                 "systemPrompt": system_prompt,
                 "messages": messages,
@@ -266,7 +388,7 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
 
 async fn list_tools(iii: &III, agent_id: &str) -> Result<Value, IIIError> {
     let config: Option<AgentConfig> = iii
-        .trigger("state::get", json!({ "scope": "agents", "key": agent_id }))
+        .trigger_v0("state::get", json!({ "scope": "agents", "key": agent_id }))
         .await
         .ok()
         .and_then(|v| serde_json::from_value(v).ok());
@@ -284,7 +406,7 @@ async fn list_tools(iii: &III, agent_id: &str) -> Result<Value, IIIError> {
         .collect();
 
     let all_functions: Value = iii
-        .trigger("engine::functions::list", json!({}))
+        .trigger_v0("engine::functions::list", json!({}))
         .await
         .unwrap_or(json!([]));
 
@@ -1189,7 +1311,7 @@ mod tests {
 async fn create_agent(iii: &III, config: AgentConfig) -> Result<Value, IIIError> {
     let agent_id = config.id.clone().unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": "agents",
         "key": &agent_id,
         "value": {

--- a/workers/bridge/src/main.rs
+++ b/workers/bridge/src/main.rs
@@ -1,8 +1,130 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use dashmap::DashMap;
 use std::sync::Arc;
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 mod types;
 
@@ -51,7 +173,7 @@ async fn register_runtime(iii: &III, req: RegisterRuntimeRequest) -> Result<Valu
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": runtimes_scope(),
         "key": &id,
         "value": value,
@@ -68,7 +190,7 @@ async fn invoke_runtime(
     active_runs: &Arc<DashMap<String, tokio::task::JoinHandle<()>>>,
 ) -> Result<Value, IIIError> {
     let config_val = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": runtimes_scope(),
             "key": &req.runtime_id,
         }))
@@ -94,7 +216,7 @@ async fn invoke_runtime(
     };
 
     let run_val = serde_json::to_value(&run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": runs_scope(),
         "key": &run_id,
         "value": run_val,
@@ -127,7 +249,7 @@ async fn invoke_runtime(
         };
 
         let val = serde_json::to_value(&finished_run).unwrap();
-        let _ = iii_bg.trigger("state::set", json!({
+        let _ = iii_bg.trigger_v0("state::set", json!({
             "scope": runs_scope(),
             "key": &run_id_bg,
             "value": val,
@@ -156,7 +278,7 @@ async fn execute_runtime(iii: &III, config: &RuntimeConfig, context: &Value, tim
             let url = config.url.as_deref().ok_or_else(|| IIIError::Handler("missing url".into()))?;
 
             let result = iii
-                .trigger("http::post", json!({
+                .trigger_v0("http::post", json!({
                     "url": url,
                     "body": context,
                     "headers": config.headers,
@@ -231,7 +353,7 @@ async fn cancel_run(
     if let Some((_, handle)) = active_runs.remove(&req.run_id) {
         handle.abort();
 
-        let _ = iii.trigger("state::update", json!({
+        let _ = iii.trigger_v0("state::update", json!({
             "scope": runs_scope(),
             "key": &req.run_id,
             "path": "status",
@@ -246,13 +368,13 @@ async fn cancel_run(
 }
 
 async fn list_runtimes(iii: &III) -> Result<Value, IIIError> {
-    iii.trigger("state::list", json!({ "scope": runtimes_scope() }))
+    iii.trigger_v0("state::list", json!({ "scope": runtimes_scope() }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
 async fn get_run(iii: &III, run_id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::get", json!({
+    iii.trigger_v0("state::get", json!({
         "scope": runs_scope(),
         "key": run_id,
     }))
@@ -264,7 +386,7 @@ async fn get_run(iii: &III, run_id: &str) -> Result<Value, IIIError> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
     let active_runs: Arc<DashMap<String, tokio::task::JoinHandle<()>>> = Arc::new(DashMap::new());
 
     let iii_clone = iii.clone();
@@ -338,11 +460,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "bridge::register", json!({ "method": "POST", "path": "/api/bridge/runtimes" }))?;
-    iii.register_trigger("http", "bridge::invoke", json!({ "method": "POST", "path": "/api/bridge/invoke" }))?;
-    iii.register_trigger("http", "bridge::cancel", json!({ "method": "POST", "path": "/api/bridge/cancel" }))?;
-    iii.register_trigger("http", "bridge::list", json!({ "method": "GET", "path": "/api/bridge/runtimes" }))?;
-    iii.register_trigger("http", "bridge::run", json!({ "method": "GET", "path": "/api/bridge/runs/:runId" }))?;
+    iii.register_trigger_v0("http", "bridge::register", json!({ "method": "POST", "path": "/api/bridge/runtimes" }))?;
+    iii.register_trigger_v0("http", "bridge::invoke", json!({ "method": "POST", "path": "/api/bridge/invoke" }))?;
+    iii.register_trigger_v0("http", "bridge::cancel", json!({ "method": "POST", "path": "/api/bridge/cancel" }))?;
+    iii.register_trigger_v0("http", "bridge::list", json!({ "method": "GET", "path": "/api/bridge/runtimes" }))?;
+    iii.register_trigger_v0("http", "bridge::run", json!({ "method": "GET", "path": "/api/bridge/runs/:runId" }))?;
 
     tracing::info!("bridge worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/council/src/main.rs
+++ b/workers/council/src/main.rs
@@ -1,7 +1,129 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 mod types;
 
@@ -20,7 +142,7 @@ fn activity_scope(realm_id: &str) -> String {
 
 async fn get_prev_hash(iii: &III, realm_id: &str) -> String {
     let entries = iii
-        .trigger("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
         .await
         .ok();
 
@@ -70,7 +192,7 @@ async fn log_activity(iii: &III, req: LogActivityRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&entry).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": activity_scope(&req.realm_id),
         "key": id,
         "value": value,
@@ -101,7 +223,7 @@ async fn submit_proposal(iii: &III, req: SubmitProposalRequest) -> Result<Value,
 
     let value = serde_json::to_value(&proposal).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": proposals_scope(&req.realm_id),
         "key": id,
         "value": value,
@@ -132,7 +254,7 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
     let realm_id = &req.realm_id;
 
     let val = iii
-        .trigger("state::get", json!({ "scope": proposals_scope(realm_id), "key": &req.id }))
+        .trigger_v0("state::get", json!({ "scope": proposals_scope(realm_id), "key": &req.id }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -157,7 +279,7 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
 
     let value = serde_json::to_value(&proposal).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": proposals_scope(realm_id),
         "key": proposal.id,
         "value": value,
@@ -190,7 +312,7 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
 
 async fn list_proposals(iii: &III, realm_id: &str, status_filter: Option<ProposalStatus>) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": proposals_scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": proposals_scope(realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -219,7 +341,7 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
     };
 
     let _ = iii
-        .trigger("state::update", json!({
+        .trigger_v0("state::update", json!({
             "scope": "agents",
             "key": &req.target_agent_id,
             "path": "status",
@@ -257,7 +379,7 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
 
 async fn get_activity_log(iii: &III, realm_id: &str, limit: usize) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -281,7 +403,7 @@ async fn get_activity_log(iii: &III, realm_id: &str, limit: usize) -> Result<Val
 
 async fn verify_activity_chain(iii: &III, realm_id: &str) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -322,7 +444,7 @@ async fn verify_activity_chain(iii: &III, realm_id: &str) -> Result<Value, IIIEr
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -429,14 +551,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "council::submit", json!({ "method": "POST", "path": "/api/council/proposals" }))?;
-    iii.register_trigger("http", "council::decide", json!({ "method": "POST", "path": "/api/council/proposals/:id/decide" }))?;
-    iii.register_trigger("http", "council::proposals", json!({ "method": "GET", "path": "/api/council/proposals/:realmId" }))?;
-    iii.register_trigger("http", "council::override", json!({ "method": "POST", "path": "/api/council/override" }))?;
-    iii.register_trigger("http", "council::activity_log", json!({ "method": "GET", "path": "/api/council/activity/:realmId" }))?;
-    iii.register_trigger("http", "council::verify", json!({ "method": "GET", "path": "/api/council/verify/:realmId" }))?;
+    iii.register_trigger_v0("http", "council::submit", json!({ "method": "POST", "path": "/api/council/proposals" }))?;
+    iii.register_trigger_v0("http", "council::decide", json!({ "method": "POST", "path": "/api/council/proposals/:id/decide" }))?;
+    iii.register_trigger_v0("http", "council::proposals", json!({ "method": "GET", "path": "/api/council/proposals/:realmId" }))?;
+    iii.register_trigger_v0("http", "council::override", json!({ "method": "POST", "path": "/api/council/override" }))?;
+    iii.register_trigger_v0("http", "council::activity_log", json!({ "method": "GET", "path": "/api/council/activity/:realmId" }))?;
+    iii.register_trigger_v0("http", "council::verify", json!({ "method": "GET", "path": "/api/council/verify/:realmId" }))?;
 
-    iii.register_trigger("subscribe", "council::activity", json!({ "topic": "council.audit" }))?;
+    iii.register_trigger_v0("subscribe", "council::activity", json!({ "topic": "council.audit" }))?;
 
     tracing::info!("council worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/directive/src/main.rs
+++ b/workers/directive/src/main.rs
@@ -1,6 +1,128 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 mod types;
 
@@ -16,7 +138,7 @@ fn scope(realm_id: &str) -> String {
 async fn create_directive(iii: &III, req: CreateDirectiveRequest) -> Result<Value, IIIError> {
     if let Some(ref parent_id) = req.parent_id {
         let parent = iii
-            .trigger("state::get", json!({ "scope": scope(&req.realm_id), "key": parent_id }))
+            .trigger_v0("state::get", json!({ "scope": scope(&req.realm_id), "key": parent_id }))
             .await
             .map_err(|e| IIIError::Handler(format!("parent directive not found: {e}")))?;
 
@@ -45,7 +167,7 @@ async fn create_directive(iii: &III, req: CreateDirectiveRequest) -> Result<Valu
 
     let value = serde_json::to_value(&directive).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": scope(&req.realm_id),
         "key": id,
         "value": value,
@@ -62,7 +184,7 @@ async fn create_directive(iii: &III, req: CreateDirectiveRequest) -> Result<Valu
 }
 
 async fn get_directive(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::get", json!({
+    iii.trigger_v0("state::get", json!({
         "scope": scope(realm_id),
         "key": id,
     }))
@@ -72,7 +194,7 @@ async fn get_directive(iii: &III, realm_id: &str, id: &str) -> Result<Value, III
 
 async fn list_directives(iii: &III, req: ListDirectivesRequest) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": scope(&req.realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": scope(&req.realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -99,7 +221,7 @@ async fn list_directives(iii: &III, req: ListDirectivesRequest) -> Result<Value,
 async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Value, IIIError> {
     let realm_id = &req.realm_id;
     let existing = iii
-        .trigger("state::get", json!({ "scope": scope(realm_id), "key": &req.id }))
+        .trigger_v0("state::get", json!({ "scope": scope(realm_id), "key": &req.id }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -127,7 +249,7 @@ async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Valu
 
     let value = serde_json::to_value(&d).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": scope(realm_id),
         "key": d.id,
         "value": value,
@@ -141,7 +263,7 @@ async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Valu
 
 async fn get_ancestry(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": scope(realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -186,7 +308,7 @@ async fn get_ancestry(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIE
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -266,11 +388,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "directive::create", json!({ "method": "POST", "path": "/api/directives" }))?;
-    iii.register_trigger("http", "directive::get", json!({ "method": "GET", "path": "/api/directives/:realmId/:id" }))?;
-    iii.register_trigger("http", "directive::list", json!({ "method": "GET", "path": "/api/directives/:realmId" }))?;
-    iii.register_trigger("http", "directive::update", json!({ "method": "PATCH", "path": "/api/directives/:realmId/:id" }))?;
-    iii.register_trigger("http", "directive::ancestry", json!({ "method": "GET", "path": "/api/directives/:realmId/:id/ancestry" }))?;
+    iii.register_trigger_v0("http", "directive::create", json!({ "method": "POST", "path": "/api/directives" }))?;
+    iii.register_trigger_v0("http", "directive::get", json!({ "method": "GET", "path": "/api/directives/:realmId/:id" }))?;
+    iii.register_trigger_v0("http", "directive::list", json!({ "method": "GET", "path": "/api/directives/:realmId" }))?;
+    iii.register_trigger_v0("http", "directive::update", json!({ "method": "PATCH", "path": "/api/directives/:realmId/:id" }))?;
+    iii.register_trigger_v0("http", "directive::ancestry", json!({ "method": "GET", "path": "/api/directives/:realmId/:id/ancestry" }))?;
 
     tracing::info!("directive worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/hierarchy/src/main.rs
+++ b/workers/hierarchy/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -6,6 +6,128 @@ use std::collections::{HashMap, HashSet};
 mod types;
 
 use types::{ChainRequest, FindByCapabilityRequest, HierarchyNode, SetHierarchyRequest, TreeNode, TreeRequest};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 fn scope(realm_id: &str) -> String {
     format!("realm:{realm_id}:hierarchy")
@@ -34,7 +156,7 @@ async fn set_node(iii: &III, req: SetHierarchyRequest) -> Result<Value, IIIError
 
     let value = serde_json::to_value(&node).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": scope(&req.realm_id),
         "key": node.agent_id,
         "value": value,
@@ -70,7 +192,7 @@ fn would_create_cycle(nodes: &[HierarchyNode], agent_id: &str, new_parent: &str)
 
 async fn load_all(iii: &III, realm_id: &str) -> Result<Vec<HierarchyNode>, IIIError> {
     let result = iii
-        .trigger("state::list", json!({ "scope": scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": scope(realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -195,7 +317,7 @@ async fn get_chain(iii: &III, req: ChainRequest) -> Result<Value, IIIError> {
 }
 
 async fn remove_node(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::delete", json!({
+    iii.trigger_v0("state::delete", json!({
         "scope": scope(realm_id),
         "key": agent_id,
     }))
@@ -209,7 +331,7 @@ async fn remove_node(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value,
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -285,11 +407,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "hierarchy::set", json!({ "method": "POST", "path": "/api/hierarchy" }))?;
-    iii.register_trigger("http", "hierarchy::tree", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/tree" }))?;
-    iii.register_trigger("http", "hierarchy::find", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/find" }))?;
-    iii.register_trigger("http", "hierarchy::chain", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/chain/:agentId" }))?;
-    iii.register_trigger("http", "hierarchy::remove", json!({ "method": "DELETE", "path": "/api/hierarchy/:realmId/:agentId" }))?;
+    iii.register_trigger_v0("http", "hierarchy::set", json!({ "method": "POST", "path": "/api/hierarchy" }))?;
+    iii.register_trigger_v0("http", "hierarchy::tree", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/tree" }))?;
+    iii.register_trigger_v0("http", "hierarchy::find", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/find" }))?;
+    iii.register_trigger_v0("http", "hierarchy::chain", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/chain/:agentId" }))?;
+    iii.register_trigger_v0("http", "hierarchy::remove", json!({ "method": "DELETE", "path": "/api/hierarchy/:realmId/:agentId" }))?;
 
     tracing::info!("hierarchy worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/ledger/src/main.rs
+++ b/workers/ledger/src/main.rs
@@ -1,6 +1,128 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 mod types;
 
@@ -25,7 +147,7 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
         .to_string();
 
     let existing = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": budget_scope(&req.realm_id),
             "key": &key,
         }))
@@ -54,7 +176,7 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
 
     let value = serde_json::to_value(&budget).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": budget_scope(&req.realm_id),
         "key": key,
         "value": value,
@@ -67,7 +189,7 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
 
 async fn check_budget(iii: &III, req: CheckBudgetRequest) -> Result<Value, IIIError> {
     let agent_budget = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": budget_scope(&req.realm_id),
             "key": &req.agent_id,
         }))
@@ -75,7 +197,7 @@ async fn check_budget(iii: &III, req: CheckBudgetRequest) -> Result<Value, IIIEr
         .ok();
 
     let realm_budget = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": budget_scope(&req.realm_id),
             "key": "realm",
         }))
@@ -152,7 +274,7 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
             },
         }));
 
-        let _ = iii.trigger(
+        let _ = iii.trigger_v0(
             "council::activity",
             json!({
                 "realmId": req.realm_id,
@@ -187,7 +309,7 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&event).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": spend_scope(&req.realm_id),
         "key": event.id,
         "value": value,
@@ -196,7 +318,7 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let budget_val = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": budget_scope(&req.realm_id),
             "key": &req.agent_id,
         }))
@@ -212,7 +334,7 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
             let updated = serde_json::to_value(&budget).map_err(|e| IIIError::Handler(e.to_string()))?;
             let _ = iii
-                .trigger("state::set", json!({
+                .trigger_v0("state::set", json!({
                     "scope": budget_scope(&req.realm_id),
                     "key": &req.agent_id,
                     "value": updated,
@@ -240,7 +362,7 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
 async fn get_summary(iii: &III, req: SummaryRequest) -> Result<Value, IIIError> {
     let events = iii
-        .trigger("state::list", json!({ "scope": spend_scope(&req.realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": spend_scope(&req.realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -284,7 +406,7 @@ async fn get_summary(iii: &III, req: SummaryRequest) -> Result<Value, IIIError> 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -342,12 +464,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "ledger::set_budget", json!({ "method": "POST", "path": "/api/ledger/budget" }))?;
-    iii.register_trigger("http", "ledger::check", json!({ "method": "GET", "path": "/api/ledger/check/:realmId/:agentId" }))?;
-    iii.register_trigger("http", "ledger::spend", json!({ "method": "POST", "path": "/api/ledger/spend" }))?;
-    iii.register_trigger("http", "ledger::summary", json!({ "method": "GET", "path": "/api/ledger/summary/:realmId" }))?;
+    iii.register_trigger_v0("http", "ledger::set_budget", json!({ "method": "POST", "path": "/api/ledger/budget" }))?;
+    iii.register_trigger_v0("http", "ledger::check", json!({ "method": "GET", "path": "/api/ledger/check/:realmId/:agentId" }))?;
+    iii.register_trigger_v0("http", "ledger::spend", json!({ "method": "POST", "path": "/api/ledger/spend" }))?;
+    iii.register_trigger_v0("http", "ledger::summary", json!({ "method": "GET", "path": "/api/ledger/summary/:realmId" }))?;
 
-    iii.register_trigger("subscribe", "ledger::spend", json!({ "topic": "cost.incurred" }))?;
+    iii.register_trigger_v0("subscribe", "ledger::spend", json!({ "topic": "cost.incurred" }))?;
 
     tracing::info!("ledger worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/llm-router/src/main.rs
+++ b/workers/llm-router/src/main.rs
@@ -1,9 +1,131 @@
 use dashmap::DashMap;
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Instant;
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 struct RouterState {
     usage: DashMap<String, Usage>,
@@ -163,7 +285,7 @@ async fn call_openai_compat(
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let state = Arc::new(RouterState {
         usage: DashMap::new(),

--- a/workers/memory/src/main.rs
+++ b/workers/memory/src/main.rs
@@ -1,9 +1,131 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct MemoryEntry {
@@ -26,7 +148,7 @@ struct MemoryEntry {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_ref = iii.clone();
     iii.register_function_with_description(
@@ -96,7 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_ref.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("default");
-                iii.trigger("state::list", json!({ "scope": format!("sessions:{}", agent_id) }))
+                iii.trigger_v0("state::list", json!({ "scope": format!("sessions:{}", agent_id) }))
                     .await
                     .map_err(|e| IIIError::Handler(e.to_string()))
             }
@@ -123,9 +245,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("cron", "memory::consolidate", json!({ "expression": "0 */6 * * *" }))?;
+    iii.register_trigger_v0("cron", "memory::consolidate", json!({ "expression": "0 */6 * * *" }))?;
 
-    iii.register_trigger("cron", "memory::evict", json!({ "expression": "0 3 * * *" }))?;
+    iii.register_trigger_v0("cron", "memory::evict", json!({ "expression": "0 3 * * *" }))?;
 
     tracing::info!("memory worker started");
     tokio::signal::ctrl_c().await?;
@@ -146,7 +268,7 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     };
 
     let existing: Option<Value> = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": format!("memory:{}", agent_id),
             "key": &hash,
         }))
@@ -161,7 +283,7 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     let now = now_ms();
 
     let embedding: Option<Vec<f64>> = iii
-        .trigger("embedding::generate", json!({ "text": content }))
+        .trigger_v0("embedding::generate", json!({ "text": content }))
         .await
         .ok()
         .and_then(|v| {
@@ -186,20 +308,20 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
         "lastAccessed": now,
     });
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": format!("memory:{}", agent_id),
         "key": &id,
         "value": &entry,
     })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": format!("memory:{}", agent_id),
         "key": &hash,
         "value": { "id": &id, "timestamp": now },
     })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     if let Some(sid) = &session_id {
-        let _ = iii.trigger("state::update", json!({
+        let _ = iii.trigger_v0("state::update", json!({
             "scope": format!("sessions:{}", agent_id),
             "key": sid,
             "operations": [
@@ -218,7 +340,7 @@ async fn recall_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     let limit = input["limit"].as_u64().unwrap_or(10) as usize;
 
     let entries: Value = iii
-        .trigger("state::list", json!({ "scope": format!("memory:{}", agent_id) }))
+        .trigger_v0("state::list", json!({ "scope": format!("memory:{}", agent_id) }))
         .await
         .unwrap_or(json!([]));
 
@@ -240,7 +362,7 @@ async fn recall_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let query_embedding: Option<Vec<f64>> = iii
-        .trigger("embedding::generate", json!({ "text": query }))
+        .trigger_v0("embedding::generate", json!({ "text": query }))
         .await
         .ok()
         .and_then(|v| {
@@ -314,7 +436,7 @@ async fn kg_add(iii: &III, input: Value) -> Result<Value, IIIError> {
     let entity = &input["entity"];
     let entity_id = entity["id"].as_str().unwrap_or("");
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": format!("kg:{}", agent_id),
         "key": entity_id,
         "value": entity,
@@ -325,7 +447,7 @@ async fn kg_add(iii: &III, input: Value) -> Result<Value, IIIError> {
             let target_id = rel["target"].as_str().unwrap_or("");
             let rel_type = rel["type"].as_str().unwrap_or("");
 
-            if let Ok(target) = iii.trigger("state::get", json!({
+            if let Ok(target) = iii.trigger_v0("state::get", json!({
                 "scope": format!("kg:{}", agent_id),
                 "key": target_id,
             })).await {
@@ -340,7 +462,7 @@ async fn kg_add(iii: &III, input: Value) -> Result<Value, IIIError> {
 
                 if !already {
                     back_refs.push(json!({ "target": entity_id, "type": format!("inverse:{}", rel_type) }));
-                    let _ = iii.trigger("state::update", json!({
+                    let _ = iii.trigger_v0("state::update", json!({
                         "scope": format!("kg:{}", agent_id),
                         "key": target_id,
                         "operations": [{ "type": "set", "path": "relations", "value": back_refs }],
@@ -368,7 +490,7 @@ async fn kg_query(iii: &III, input: Value) -> Result<Value, IIIError> {
         }
         visited.insert(id.clone());
 
-        if let Ok(entity) = iii.trigger("state::get", json!({
+        if let Ok(entity) = iii.trigger_v0("state::get", json!({
             "scope": format!("kg:{}", agent_id),
             "key": &id,
         })).await {
@@ -392,7 +514,7 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
     let cap = input["cap"].as_u64().unwrap_or(10_000) as usize;
 
     let scopes: Value = iii
-        .trigger("state::list_groups", json!({}))
+        .trigger_v0("state::list_groups", json!({}))
         .await
         .unwrap_or(json!([]));
 
@@ -410,7 +532,7 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     for scope in &memory_scopes {
         let entries: Value = iii
-            .trigger("state::list", json!({ "scope": scope }))
+            .trigger_v0("state::list", json!({ "scope": scope }))
             .await
             .unwrap_or(json!([]));
 
@@ -433,8 +555,8 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
             let is_low_confidence = m.confidence < 0.1;
 
             if (is_stale && is_low_value) || is_low_confidence {
-                let _ = iii.trigger("state::delete", json!({ "scope": scope, "key": &m.id })).await;
-                let _ = iii.trigger("state::delete", json!({ "scope": scope, "key": &m.hash })).await;
+                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.id })).await;
+                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.hash })).await;
                 scope_evicted += 1;
             }
         }
@@ -446,7 +568,7 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
 
             let overflow = (remaining - cap as u64) as usize;
             for m in sorted.into_iter().take(overflow) {
-                let _ = iii.trigger("state::delete", json!({ "scope": scope, "key": &m.id })).await;
+                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.id })).await;
                 scope_evicted += 1;
             }
         }
@@ -462,7 +584,7 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
     let start = std::time::Instant::now();
 
     let scopes: Value = iii
-        .trigger("state::list_groups", json!({}))
+        .trigger_v0("state::list_groups", json!({}))
         .await
         .unwrap_or(json!([]));
 
@@ -481,7 +603,7 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     for scope in &memory_scopes {
         let entries: Value = iii
-            .trigger("state::list", json!({ "scope": scope }))
+            .trigger_v0("state::list", json!({ "scope": scope }))
             .await
             .unwrap_or(json!([]));
 
@@ -500,7 +622,7 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
 
             if now.saturating_sub(last_accessed) > seven_days_ms && confidence > 0.1 {
                 let new_confidence = (confidence * (1.0 - decay_rate)).max(0.1);
-                let _ = iii.trigger("state::update", json!({
+                let _ = iii.trigger_v0("state::update", json!({
                     "scope": scope,
                     "key": id,
                     "operations": [
@@ -526,7 +648,7 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let keep_recent = input["keepRecent"].as_u64().unwrap_or(10) as usize;
 
     let session: Value = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
         }))
@@ -545,7 +667,7 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut full_messages = Vec::new();
     for msg_ref in to_summarize {
         let msg_id = msg_ref["id"].as_str().unwrap_or("");
-        if let Ok(entry) = iii.trigger("state::get", json!({
+        if let Ok(entry) = iii.trigger_v0("state::get", json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
         })).await {
@@ -562,7 +684,7 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut summaries = Vec::new();
 
     for chunk in &chunks {
-        let summary = iii.trigger("llm::complete", json!({
+        let summary = iii.trigger_v0("llm::complete", json!({
             "model": { "provider": "anthropic", "model": "claude-haiku-4-5", "maxTokens": 1024 },
             "systemPrompt": "Summarize this conversation concisely. Preserve key facts, decisions, and context. Be brief.",
             "messages": [{ "role": "user", "content": chunk }],
@@ -578,7 +700,7 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let summary_id = uuid::Uuid::new_v4().to_string();
     let now = now_ms();
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": format!("memory:{}", agent_id),
         "key": &summary_id,
         "value": {
@@ -599,7 +721,7 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut new_messages = vec![json!({ "id": summary_id, "role": "system", "timestamp": now })];
     new_messages.extend(to_keep.iter().cloned());
 
-    iii.trigger("state::update", json!({
+    iii.trigger_v0("state::update", json!({
         "scope": format!("sessions:{}", agent_id),
         "key": session_id,
         "operations": [
@@ -621,7 +743,7 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let session_id = input["sessionId"].as_str().unwrap_or("default");
 
     let session: Value = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
         }))
@@ -668,7 +790,7 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut orphaned = 0_u64;
     for msg in &repaired {
         let msg_id = msg["id"].as_str().unwrap_or("");
-        let exists = iii.trigger("state::get", json!({
+        let exists = iii.trigger_v0("state::get", json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
         })).await;
@@ -695,7 +817,7 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut truncated = 0_u64;
     for msg in &repaired {
         let msg_id = msg["id"].as_str().unwrap_or("");
-        if let Ok(entry) = iii.trigger("state::get", json!({
+        if let Ok(entry) = iii.trigger_v0("state::get", json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
         })).await {
@@ -709,7 +831,7 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     let total_repairs: u64 = stats.values().sum();
     if total_repairs > 0 {
-        iii.trigger("state::update", json!({
+        iii.trigger_v0("state::update", json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
             "operations": [

--- a/workers/mission/src/main.rs
+++ b/workers/mission/src/main.rs
@@ -1,6 +1,128 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 mod types;
 
@@ -42,7 +164,7 @@ async fn create_mission(iii: &III, req: CreateMissionRequest) -> Result<Value, I
 
     let value = serde_json::to_value(&mission).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": scope(&req.realm_id),
         "key": id,
         "value": value,
@@ -60,7 +182,7 @@ async fn create_mission(iii: &III, req: CreateMissionRequest) -> Result<Value, I
 
 async fn load_mission(iii: &III, realm_id: &str, id: &str) -> Result<Mission, IIIError> {
     let val = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": scope(realm_id),
             "key": id,
         }))
@@ -72,7 +194,7 @@ async fn load_mission(iii: &III, realm_id: &str, id: &str) -> Result<Mission, II
 
 async fn save_mission(iii: &III, mission: &Mission) -> Result<(), IIIError> {
     let value = serde_json::to_value(mission).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": scope(&mission.realm_id),
         "key": mission.id,
         "value": value,
@@ -191,7 +313,7 @@ async fn add_comment(iii: &III, req: CommentRequest) -> Result<Value, IIIError> 
 
     let value = serde_json::to_value(&comment).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": comments_scope(&realm_id, &req.mission_id),
         "key": id,
         "value": value,
@@ -203,7 +325,7 @@ async fn add_comment(iii: &III, req: CommentRequest) -> Result<Value, IIIError> 
 }
 
 async fn list_comments(iii: &III, realm_id: &str, mission_id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::list", json!({
+    iii.trigger_v0("state::list", json!({
         "scope": comments_scope(realm_id, mission_id),
     }))
     .await
@@ -212,7 +334,7 @@ async fn list_comments(iii: &III, realm_id: &str, mission_id: &str) -> Result<Va
 
 async fn list_missions(iii: &III, req: ListMissionsRequest) -> Result<Value, IIIError> {
     let all = iii
-        .trigger("state::list", json!({ "scope": scope(&req.realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": scope(&req.realm_id) }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -241,7 +363,7 @@ async fn list_missions(iii: &III, req: ListMissionsRequest) -> Result<Value, III
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -352,13 +474,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "mission::create", json!({ "method": "POST", "path": "/api/missions" }))?;
-    iii.register_trigger("http", "mission::checkout", json!({ "method": "POST", "path": "/api/missions/:id/checkout" }))?;
-    iii.register_trigger("http", "mission::release", json!({ "method": "POST", "path": "/api/missions/:id/release" }))?;
-    iii.register_trigger("http", "mission::transition", json!({ "method": "PATCH", "path": "/api/missions/:id/status" }))?;
-    iii.register_trigger("http", "mission::list", json!({ "method": "GET", "path": "/api/missions/:realmId" }))?;
-    iii.register_trigger("http", "mission::comment", json!({ "method": "POST", "path": "/api/missions/:id/comments" }))?;
-    iii.register_trigger("http", "mission::comments", json!({ "method": "GET", "path": "/api/missions/:realmId/:missionId/comments" }))?;
+    iii.register_trigger_v0("http", "mission::create", json!({ "method": "POST", "path": "/api/missions" }))?;
+    iii.register_trigger_v0("http", "mission::checkout", json!({ "method": "POST", "path": "/api/missions/:id/checkout" }))?;
+    iii.register_trigger_v0("http", "mission::release", json!({ "method": "POST", "path": "/api/missions/:id/release" }))?;
+    iii.register_trigger_v0("http", "mission::transition", json!({ "method": "PATCH", "path": "/api/missions/:id/status" }))?;
+    iii.register_trigger_v0("http", "mission::list", json!({ "method": "GET", "path": "/api/missions/:realmId" }))?;
+    iii.register_trigger_v0("http", "mission::comment", json!({ "method": "POST", "path": "/api/missions/:id/comments" }))?;
+    iii.register_trigger_v0("http", "mission::comments", json!({ "method": "GET", "path": "/api/missions/:realmId/:missionId/comments" }))?;
 
     tracing::info!("mission worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/pulse/src/main.rs
+++ b/workers/pulse/src/main.rs
@@ -1,10 +1,132 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
 mod types;
 
 use types::{ContextMode, InvokeRequest, PulseConfig, PulseRun, PulseStatus, RegisterPulseRequest};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 fn config_scope(realm_id: &str) -> String {
     format!("realm:{realm_id}:pulse:config")
@@ -25,7 +147,7 @@ async fn build_context(iii: &III, agent_id: &str, realm_id: &str, mode: &Context
         }
         ContextMode::Full => {
             let missions = iii
-                .trigger("mission::list", json!({
+                .trigger_v0("mission::list", json!({
                     "realmId": realm_id,
                     "assigneeId": agent_id,
                     "status": "active",
@@ -34,7 +156,7 @@ async fn build_context(iii: &III, agent_id: &str, realm_id: &str, mode: &Context
                 .unwrap_or(json!({ "missions": [] }));
 
             let budget = iii
-                .trigger("ledger::check", json!({
+                .trigger_v0("ledger::check", json!({
                     "realmId": realm_id,
                     "agentId": agent_id,
                 }))
@@ -42,7 +164,7 @@ async fn build_context(iii: &III, agent_id: &str, realm_id: &str, mode: &Context
                 .unwrap_or(json!({ "allowed": true }));
 
             let hierarchy = iii
-                .trigger("hierarchy::chain", json!({
+                .trigger_v0("hierarchy::chain", json!({
                     "realmId": realm_id,
                     "agentId": agent_id,
                 }))
@@ -50,7 +172,7 @@ async fn build_context(iii: &III, agent_id: &str, realm_id: &str, mode: &Context
                 .unwrap_or(json!({ "chain": [] }));
 
             let directives = iii
-                .trigger("directive::list", json!({
+                .trigger_v0("directive::list", json!({
                     "realmId": realm_id,
                     "status": "active",
                 }))
@@ -83,7 +205,7 @@ async fn register_pulse(iii: &III, req: RegisterPulseRequest) -> Result<Value, I
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": config_scope(&req.realm_id),
         "key": &req.agent_id,
         "value": value,
@@ -92,7 +214,7 @@ async fn register_pulse(iii: &III, req: RegisterPulseRequest) -> Result<Value, I
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let _ = iii
-        .trigger("engine::triggers::register", json!({
+        .trigger_v0("engine::triggers::register", json!({
             "type": "cron",
             "function": "pulse::tick",
             "config": {
@@ -127,7 +249,7 @@ async fn invoke_pulse(iii: &III, req: InvokeRequest) -> Result<Value, IIIError> 
     };
 
     let run_val = serde_json::to_value(&run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": runs_scope(&realm_id),
         "key": &run_id,
         "value": run_val,
@@ -136,7 +258,7 @@ async fn invoke_pulse(iii: &III, req: InvokeRequest) -> Result<Value, IIIError> 
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let result = iii
-        .trigger("agent::chat", json!({
+        .trigger_v0("agent::chat", json!({
             "agentId": req.agent_id,
             "message": "You have been invoked via pulse. Review your current context and take appropriate action.",
             "context": context,
@@ -156,7 +278,7 @@ async fn invoke_pulse(iii: &III, req: InvokeRequest) -> Result<Value, IIIError> 
     };
 
     let run_val = serde_json::to_value(&finished_run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    let _ = iii.trigger("state::set", json!({
+    let _ = iii.trigger_v0("state::set", json!({
         "scope": runs_scope(&realm_id),
         "key": &run_id,
         "value": run_val,
@@ -175,7 +297,7 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
         .ok_or_else(|| IIIError::Handler("missing realmId in tick".into()))?;
 
     let config_val = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
         }))
@@ -190,7 +312,7 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let budget_check = iii
-        .trigger("ledger::check", json!({
+        .trigger_v0("ledger::check", json!({
             "realmId": realm_id,
             "agentId": agent_id,
         }))
@@ -211,7 +333,7 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
 
 async fn get_pulse_status(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value, IIIError> {
     let config = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
         }))
@@ -219,7 +341,7 @@ async fn get_pulse_status(iii: &III, realm_id: &str, agent_id: &str) -> Result<V
         .ok();
 
     let runs = iii
-        .trigger("state::list", json!({ "scope": runs_scope(realm_id) }))
+        .trigger_v0("state::list", json!({ "scope": runs_scope(realm_id) }))
         .await
         .ok();
 
@@ -242,7 +364,7 @@ async fn get_pulse_status(iii: &III, realm_id: &str, agent_id: &str) -> Result<V
 
 async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) -> Result<Value, IIIError> {
     let config_val = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
         }))
@@ -256,7 +378,7 @@ async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) 
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": config_scope(realm_id),
         "key": agent_id,
         "value": value,
@@ -271,7 +393,7 @@ async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -348,10 +470,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "pulse::register", json!({ "method": "POST", "path": "/api/pulse/register" }))?;
-    iii.register_trigger("http", "pulse::invoke", json!({ "method": "POST", "path": "/api/pulse/invoke" }))?;
-    iii.register_trigger("http", "pulse::status", json!({ "method": "GET", "path": "/api/pulse/:realmId/:agentId" }))?;
-    iii.register_trigger("http", "pulse::toggle", json!({ "method": "PATCH", "path": "/api/pulse/:realmId/:agentId" }))?;
+    iii.register_trigger_v0("http", "pulse::register", json!({ "method": "POST", "path": "/api/pulse/register" }))?;
+    iii.register_trigger_v0("http", "pulse::invoke", json!({ "method": "POST", "path": "/api/pulse/invoke" }))?;
+    iii.register_trigger_v0("http", "pulse::status", json!({ "method": "GET", "path": "/api/pulse/:realmId/:agentId" }))?;
+    iii.register_trigger_v0("http", "pulse::toggle", json!({ "method": "PATCH", "path": "/api/pulse/:realmId/:agentId" }))?;
 
     tracing::info!("pulse worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/realm/src/main.rs
+++ b/workers/realm/src/main.rs
@@ -1,10 +1,132 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
 mod types;
 
 use types::{CreateRealmRequest, ExportRequest, ImportRequest, Realm, RealmStatus, UpdateRealmRequest};
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 async fn create_realm(iii: &III, req: CreateRealmRequest) -> Result<Value, IIIError> {
     let id = format!("realm-{}", uuid::Uuid::new_v4());
@@ -25,7 +147,7 @@ async fn create_realm(iii: &III, req: CreateRealmRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&realm).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": "realms",
         "key": id,
         "value": value,
@@ -42,7 +164,7 @@ async fn create_realm(iii: &III, req: CreateRealmRequest) -> Result<Value, IIIEr
 }
 
 async fn get_realm(iii: &III, id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::get", json!({
+    iii.trigger_v0("state::get", json!({
         "scope": "realms",
         "key": id,
     }))
@@ -51,7 +173,7 @@ async fn get_realm(iii: &III, id: &str) -> Result<Value, IIIError> {
 }
 
 async fn list_realms(iii: &III) -> Result<Value, IIIError> {
-    iii.trigger("state::list", json!({ "scope": "realms" }))
+    iii.trigger_v0("state::list", json!({ "scope": "realms" }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))
 }
@@ -83,7 +205,7 @@ async fn update_realm(iii: &III, req: UpdateRealmRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&realm).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": "realms",
         "key": realm.id,
         "value": value,
@@ -100,7 +222,7 @@ async fn update_realm(iii: &III, req: UpdateRealmRequest) -> Result<Value, IIIEr
 }
 
 async fn delete_realm(iii: &III, id: &str) -> Result<Value, IIIError> {
-    iii.trigger("state::delete", json!({
+    iii.trigger_v0("state::delete", json!({
         "scope": "realms",
         "key": id,
     }))
@@ -120,17 +242,17 @@ async fn export_realm(iii: &III, req: ExportRequest) -> Result<Value, IIIError> 
     let scrub = req.scrub_secrets.unwrap_or(true);
 
     let agents = iii
-        .trigger("state::list", json!({ "scope": format!("realm:{}:agents", req.id) }))
+        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:agents", req.id) }))
         .await
         .unwrap_or(json!([]));
 
     let directives = iii
-        .trigger("state::list", json!({ "scope": format!("realm:{}:directives", req.id) }))
+        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:directives", req.id) }))
         .await
         .unwrap_or(json!([]));
 
     let hierarchy = iii
-        .trigger("state::list", json!({ "scope": format!("realm:{}:hierarchy", req.id) }))
+        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:hierarchy", req.id) }))
         .await
         .unwrap_or(json!([]));
 
@@ -179,7 +301,7 @@ async fn import_realm(iii: &III, req: ImportRequest) -> Result<Value, IIIError> 
             let mut agent = agent.clone();
             agent["realmId"] = json!(realm_id);
             let _ = iii
-                .trigger("state::set", json!({
+                .trigger_v0("state::set", json!({
                     "scope": format!("realm:{realm_id}:agents"),
                     "key": agent["id"].as_str().unwrap_or("unknown"),
                     "value": agent,
@@ -198,7 +320,7 @@ async fn import_realm(iii: &III, req: ImportRequest) -> Result<Value, IIIError> 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function_with_description(
@@ -296,13 +418,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "realm::create", json!({ "method": "POST", "path": "/api/realms" }))?;
-    iii.register_trigger("http", "realm::list", json!({ "method": "GET", "path": "/api/realms" }))?;
-    iii.register_trigger("http", "realm::get", json!({ "method": "GET", "path": "/api/realms/:id" }))?;
-    iii.register_trigger("http", "realm::update", json!({ "method": "PATCH", "path": "/api/realms/:id" }))?;
-    iii.register_trigger("http", "realm::delete", json!({ "method": "DELETE", "path": "/api/realms/:id" }))?;
-    iii.register_trigger("http", "realm::export", json!({ "method": "POST", "path": "/api/realms/:id/export" }))?;
-    iii.register_trigger("http", "realm::import", json!({ "method": "POST", "path": "/api/realms/import" }))?;
+    iii.register_trigger_v0("http", "realm::create", json!({ "method": "POST", "path": "/api/realms" }))?;
+    iii.register_trigger_v0("http", "realm::list", json!({ "method": "GET", "path": "/api/realms" }))?;
+    iii.register_trigger_v0("http", "realm::get", json!({ "method": "GET", "path": "/api/realms/:id" }))?;
+    iii.register_trigger_v0("http", "realm::update", json!({ "method": "PATCH", "path": "/api/realms/:id" }))?;
+    iii.register_trigger_v0("http", "realm::delete", json!({ "method": "DELETE", "path": "/api/realms/:id" }))?;
+    iii.register_trigger_v0("http", "realm::export", json!({ "method": "POST", "path": "/api/realms/:id/export" }))?;
+    iii.register_trigger_v0("http", "realm::import", json!({ "method": "POST", "path": "/api/realms/import" }))?;
 
     tracing::info!("realm worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/security/src/docker_sandbox.rs
+++ b/workers/security/src/docker_sandbox.rs
@@ -928,7 +928,7 @@ mod tests {
 
 pub fn register(iii: &III) {
     iii.register_function_with_description(
-        "sandbox::docker_exec",
+        "security::docker_exec",
         "Execute a command inside a Docker container sandbox",
         move |input: Value| async move { docker_exec(input).await },
     );

--- a/workers/security/src/docker_sandbox.rs
+++ b/workers/security/src/docker_sandbox.rs
@@ -4,6 +4,128 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::process::Stdio;
 
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
+
 #[derive(Debug, Serialize, Deserialize)]
 struct DockerExecRequest {
     command: Vec<String>,

--- a/workers/security/src/main.rs
+++ b/workers/security/src/main.rs
@@ -1,10 +1,132 @@
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::Sha256;
 use std::sync::OnceLock;
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -62,7 +184,7 @@ static INJECTION_PATTERNS: &[&str] = &[
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_ref = iii.clone();
     iii.register_function_with_description(
@@ -84,7 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let agent_id = input["agentId"].as_str().unwrap_or("");
                 let caps = &input["capabilities"];
 
-                iii.trigger("state::set", json!({
+                iii.trigger_v0("state::set", json!({
                     "scope": "capabilities",
                     "key": agent_id,
                     "value": caps,
@@ -130,16 +252,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("subscribe", "security::audit", json!({
+    iii.register_trigger_v0("subscribe", "security::audit", json!({
         "topic": "audit",
     }))?;
 
-    iii.register_trigger("http", "security::verify_audit", json!({
+    iii.register_trigger_v0("http", "security::verify_audit", json!({
         "api_path": "security/audit/verify",
         "http_method": "GET",
     }))?;
 
-    iii.register_trigger("http", "security::scan_injection", json!({
+    iii.register_trigger_v0("http", "security::scan_injection", json!({
         "api_path": "security/scan",
         "http_method": "POST",
     }))?;
@@ -167,7 +289,7 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let caps: Value = iii
-        .trigger("state::get", json!({
+        .trigger_v0("state::get", json!({
             "scope": "capabilities",
             "key": agent_id,
         }))
@@ -193,7 +315,7 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
     let max_tokens = caps["max_tokens_per_hour"].as_u64().unwrap_or(0);
     if max_tokens > 0 {
         let usage: Value = iii
-            .trigger("state::get", json!({ "scope": "metering", "key": agent_id }))
+            .trigger_v0("state::get", json!({ "scope": "metering", "key": agent_id }))
             .await
             .unwrap_or(json!({}));
 
@@ -213,7 +335,7 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
 
 async fn append_audit(iii: &III, input: Value) -> Result<Value, IIIError> {
     let prev: Value = iii
-        .trigger("state::get", json!({ "scope": "audit", "key": "__latest" }))
+        .trigger_v0("state::get", json!({ "scope": "audit", "key": "__latest" }))
         .await
         .unwrap_or(json!({ "hash": "0".repeat(64) }));
 
@@ -249,13 +371,13 @@ async fn append_audit(iii: &III, input: Value) -> Result<Value, IIIError> {
         "prevHash": &prev_hash,
     });
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": "audit",
         "key": &id,
         "value": &full_entry,
     })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger("state::set", json!({
+    iii.trigger_v0("state::set", json!({
         "scope": "audit",
         "key": "__latest",
         "value": { "hash": &hash, "id": &id, "timestamp": timestamp },
@@ -266,7 +388,7 @@ async fn append_audit(iii: &III, input: Value) -> Result<Value, IIIError> {
 
 async fn verify_audit(iii: &III) -> Result<Value, IIIError> {
     let entries: Value = iii
-        .trigger("state::list", json!({ "scope": "audit" }))
+        .trigger_v0("state::list", json!({ "scope": "audit" }))
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 

--- a/workers/security/src/signing.rs
+++ b/workers/security/src/signing.rs
@@ -4,6 +4,128 @@ use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
+
 fn canonicalize(manifest: &Value) -> String {
     canonical_json(manifest)
 }

--- a/workers/security/src/taint.rs
+++ b/workers/security/src/taint.rs
@@ -4,6 +4,128 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TaintLabel {
     ExternalNetwork,

--- a/workers/security/src/tool_policy.rs
+++ b/workers/security/src/tool_policy.rs
@@ -3,6 +3,128 @@ use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyRule {
     pub pattern: String,
@@ -626,7 +748,7 @@ pub fn register(iii: &III) {
                 let current_concurrency = input["currentConcurrency"].as_u64().unwrap_or(0) as u32;
 
                 let agent_policy: Option<PolicyConfig> = iii
-                    .trigger("state::get", json!({
+                    .trigger_v0("state::get", json!({
                         "scope": "policies",
                         "key": agent_id,
                     }))
@@ -635,7 +757,7 @@ pub fn register(iii: &III) {
                     .and_then(|v| serde_json::from_value(v).ok());
 
                 let global_policy: Option<PolicyConfig> = iii
-                    .trigger("state::get", json!({
+                    .trigger_v0("state::get", json!({
                         "scope": "policies",
                         "key": "__global",
                     }))
@@ -709,7 +831,7 @@ pub fn register(iii: &III) {
                     input.get("policy").cloned().unwrap_or(json!({ "rules": [] }))
                 ).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                iii.trigger("state::set", json!({
+                iii.trigger_v0("state::set", json!({
                     "scope": "policies",
                     "key": &key,
                     "value": &policy,
@@ -738,7 +860,7 @@ pub fn register(iii: &III) {
                     .unwrap_or("__global");
 
                 let policy: Value = iii
-                    .trigger("state::get", json!({
+                    .trigger_v0("state::get", json!({
                         "scope": "policies",
                         "key": key,
                     }))

--- a/workers/wasm-sandbox/iii.worker.yaml
+++ b/workers/wasm-sandbox/iii.worker.yaml
@@ -4,4 +4,4 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: agentos-wasm-sandbox
-description: WASM module execution — wasmtime fuel-metered runner, validate, list (uses wasm:: namespace, distinct from builtin sandbox::* OCI microVMs)
+description: "WASM module execution — wasmtime fuel-metered runner, validate, list (uses wasm:: namespace, distinct from builtin sandbox::* OCI microVMs)"

--- a/workers/wasm-sandbox/src/main.rs
+++ b/workers/wasm-sandbox/src/main.rs
@@ -1,11 +1,133 @@
 use dashmap::DashMap;
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{III, InitOptions, register_worker};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
 use wasmtime::*;
+
+#[allow(dead_code)]
+mod iii_compat {
+    use iii_sdk::{
+        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
+        Value,
+    };
+    use iii_sdk::error::IIIError;
+    use std::future::Future;
+
+    pub trait IIIExt {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError>;
+
+        fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError>;
+    }
+
+    impl IIIExt for III {
+        fn register_function_with_description<F, Fut>(
+            &self,
+            id: &str,
+            desc: &str,
+            f: F,
+        ) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(
+                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
+            )
+        }
+
+        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
+        where
+            F: Fn(Value) -> Fut + Send + Sync + 'static,
+            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
+        {
+            self.register_function(RegisterFunction::new_async(id.to_string(), f))
+        }
+
+        fn register_trigger_v0(
+            &self,
+            kind: &str,
+            function_id: &str,
+            config: Value,
+        ) -> Result<Trigger, IIIError> {
+            self.register_trigger(RegisterTriggerInput {
+                trigger_type: kind.to_string(),
+                function_id: function_id.to_string(),
+                config,
+                metadata: None,
+            })
+        }
+
+        async fn trigger_v0(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<Value, IIIError> {
+            self.trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+        }
+
+        fn trigger_void(
+            &self,
+            function_id: &str,
+            payload: Value,
+        ) -> Result<(), IIIError> {
+            let iii = self.clone();
+            let fid = function_id.to_string();
+            tokio::spawn(async move {
+                let _ = iii
+                    .trigger(TriggerRequest {
+                        function_id: fid,
+                        payload,
+                        action: None,
+                        timeout_ms: None,
+                    })
+                    .await;
+            });
+            Ok(())
+        }
+    }
+}
+use iii_compat::IIIExt as _;
+
+
 
 const DEFAULT_FUEL: u64 = 1_000_000;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
@@ -114,7 +236,7 @@ fn unpack_ptr_len(packed: i64) -> (u32, u32) {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default())?;
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let mut config = Config::new();
     config.consume_fuel(true);
@@ -169,9 +291,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    iii.register_trigger("http", "wasm::execute", json!({ "api_path": "wasm/execute", "http_method": "POST" }))?;
-    iii.register_trigger("http", "wasm::validate", json!({ "api_path": "wasm/validate", "http_method": "POST" }))?;
-    iii.register_trigger("http", "wasm::list_modules", json!({ "api_path": "wasm/modules", "http_method": "GET" }))?;
+    iii.register_trigger_v0("http", "wasm::execute", json!({ "api_path": "wasm/execute", "http_method": "POST" }))?;
+    iii.register_trigger_v0("http", "wasm::validate", json!({ "api_path": "wasm/validate", "http_method": "POST" }))?;
+    iii.register_trigger_v0("http", "wasm::list_modules", json!({ "api_path": "wasm/modules", "http_method": "GET" }))?;
 
     tracing::info!("wasm-sandbox worker started");
     tokio::signal::ctrl_c().await?;
@@ -280,7 +402,7 @@ async fn execute_wasm(iii: &III, cache: &ModuleCache, input: Value) -> Result<Va
                 .build()
                 .unwrap();
             rt.block_on(async {
-                let cap_check = iii_inner.trigger("security::check_capability", json!({
+                let cap_check = iii_inner.trigger_v0("security::check_capability", json!({
                     "agentId": &agent,
                     "capability": func_id.split("::").next().unwrap_or(""),
                     "resource": &func_id,
@@ -290,7 +412,7 @@ async fn execute_wasm(iii: &III, cache: &ModuleCache, input: Value) -> Result<Va
                     return json!({ "error": "capability denied" }).to_string();
                 }
 
-                match iii_inner.trigger(&func_id, args).await {
+                match iii_inner.trigger_v0(&func_id, args).await {
                     Ok(v) => v.to_string(),
                     Err(e) => json!({ "error": e.to_string() }).to_string(),
                 }


### PR DESCRIPTION
Stacked on top of #34 (worker reorg). Brings agentos onto iii-sdk **0.11.4-next.4** so the builtin `sandbox::*` worker (iii-hq/iii#1544) and other 0.11.x engine features are reachable without rewriting every handler body.

## What this PR does

- Bumps `iii-sdk = "0.8"` → `iii-sdk = "=0.11.4-next.4"` in workspace `Cargo.toml`
- Migrates **13 Rust workers** + **4 security submodules** (~370 call sites) onto the new API
- Adds a self-contained `mod iii_compat { ... }` extension trait per worker that maps the old method names to the new builder APIs — closure bodies, error types, trigger payloads stay byte-identical

## API surface migrated

| 0.8 | 0.11.4-next.4 |
|---|---|
| `let iii = register_worker(url, opts)?;` | `let iii = register_worker(url, opts);` |
| `iii.register_function_with_description(id, desc, h)` | `iii.register_function(RegisterFunction::new_async(id, h).description(desc))` |
| `iii.register_function(id, h)` (2-arg form) | `iii.register_function(RegisterFunction::new_async(id, h))` |
| `iii.register_trigger(\"kind\", id, cfg)?` | `iii.register_trigger(RegisterTriggerInput { trigger_type, function_id, config, metadata })?` |
| `iii.trigger(name, payload).await` | `iii.trigger(TriggerRequest { function_id, payload, action, timeout_ms }).await` |
| `iii.trigger_void(name, payload)?` (sync, fire-and-forget) | (removed) |

## Why a compat shim instead of a full rewrite

The new builder API requires every handler return type to be inferrable. Old closures like `move \|input: Value\| async move { ... Ok(json!(...)) }` lack an explicit error type and won't satisfy the new generic bounds without per-handler annotation. The shim trait pins `R = Value`, `O = Value`, `E = IIIError` once, so all 80+ handlers compile unmodified.

The shim is **per-worker, not shared** — each `main.rs` carries its own copy. This is intentional scaffolding, not a permanent abstraction. Future PRs can inline the native builder calls one worker at a time.

`trigger_void` is implemented via `tokio::spawn` so it preserves the original synchronous `Result<(), IIIError>` return and the fire-and-forget semantic of the 0.8 API — audit emit sites keep their `?` propagation.

## Verification

```
cargo check --workspace          # clean, zero warnings
cargo check --workspace --tests  # clean (pre-existing dead_code on test helpers)
```

## Out of scope (separate PRs)

1. **Inline native builders** — drop the per-worker shim, rewrite each `register_function_with_description` to the `RegisterFunction::new_async(...).description(...)` form at the call site. One worker at a time.
2. **Atomic-append refactor** for `council::activity` — replaces manual hash-chain with `UpdateOp::append` + nested shallow-merge (iii-hq/iii#1541, #1547). ~100 LOC saved, fixes a race in the chain.
3. **`iii-shell-client` consumption** — refactor `bridge` to use the extracted client crate from iii-hq/iii#1544 instead of in-tree shell-exec glue.
4. **`dependencies:` blocks** in each `iii.worker.yaml` (iii-hq/iii#1539) so `iii worker add ./workers/agent-core` chain-installs `llm-router`, `memory`, `security`.
5. **`iii.lock` pinning** for registry-spawned external workers (iii-hq/iii#1527).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
