### PR TITLE
refactor(workers): drop iii_compat shim across all 12 remaining workers

### DIFF
--- a/workers/agent-core/src/main.rs
+++ b/workers/agent-core/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use std::time::Instant;
@@ -7,125 +7,6 @@ mod types;
 
 use types::{AgentConfig, ChatRequest, ToolCall};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -138,83 +19,104 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "agent::chat",
-        "Process a message through the agent loop",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("agent::chat", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ChatRequest = serde_json::from_value(input)
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
                 agent_chat(&iii, req).await
             }
-        },
+        })
+        .description("Process a message through the agent loop"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "agent::list_tools",
-        "List tools available to an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("agent::list_tools", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("default");
                 list_tools(&iii, agent_id).await
             }
-        },
+        })
+        .description("List tools available to an agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "agent::create",
-        "Register a new agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("agent::create", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let config: AgentConfig = serde_json::from_value(input)
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
                 create_agent(&iii, config).await
             }
-        },
+        })
+        .description("Register a new agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "agent::list",
-        "List all agents",
-        move |_: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("agent::list", move |_: Value| {
             let iii = iii_clone.clone();
             async move {
-                iii.trigger_v0("state::list", json!({ "scope": "agents" })).await
+                iii.trigger(TriggerRequest {
+                    function_id: "state::list".to_string(),
+                    payload: json!({ "scope": "agents" }),
+                    action: None,
+                    timeout_ms: None,
+                }).await
                     .map_err(|e| IIIError::Handler(e.to_string()))
             }
-        },
+        })
+        .description("List all agents"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "agent::delete",
-        "Remove an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("agent::delete", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("");
-                iii.trigger_v0("state::delete", json!({
+                iii.trigger(TriggerRequest {
+                    function_id: "state::delete".to_string(),
+                    payload: json!({
                     "scope": "agents",
                     "key": agent_id,
-                })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+                }),
+                    action: None,
+                    timeout_ms: None,
+                }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                let _ = iii.trigger_void("publish", json!({
+                let _ = {
+                    let _iii = iii.clone();
+                    let _payload = json!({
                     "topic": "agent.lifecycle",
                     "data": { "type": "deleted", "agentId": agent_id },
-                }));
+                });
+                    tokio::spawn(async move {
+                        let _ = _iii.trigger(TriggerRequest {
+                            function_id: "publish".to_string(),
+                            payload: _payload,
+                            action: None,
+                            timeout_ms: None,
+                        }).await;
+                    });
+                };
 
-                Ok(json!({ "deleted": true }))
+                Ok::<Value, IIIError>(json!({ "deleted": true }))
             }
-        },
+        })
+        .description("Remove an agent"),
     );
 
-    iii.register_trigger_v0("queue", "agent::chat", json!({ "topic": "agent.inbox" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "queue".to_string(),
+        function_id: "agent::chat".to_string(),
+        config: json!({ "topic": "agent.inbox" }),
+        metadata: None,
+    })?;
 
     tracing::info!("agent-core worker started");
     tokio::signal::ctrl_c().await?;
@@ -226,25 +128,40 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
     let start = Instant::now();
 
     let config: Option<AgentConfig> = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": "agents",
             "key": &req.agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok()
         .and_then(|v| serde_json::from_value(v).ok());
 
     let memories: Value = iii
-        .trigger_v0("memory::recall", json!({
+        .trigger(TriggerRequest {
+            function_id: "memory::recall".to_string(),
+            payload: json!({
             "agentId": &req.agent_id,
             "query": &req.message,
             "limit": 20,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
     let tools: Value = iii
-        .trigger_v0("agent::list_tools", json!({ "agentId": &req.agent_id }))
+        .trigger(TriggerRequest {
+            function_id: "agent::list_tools".to_string(),
+            payload: json!({ "agentId": &req.agent_id }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -253,16 +170,26 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         .unwrap_or_default();
 
     let model: Value = iii
-        .trigger_v0("llm::route", json!({
+        .trigger(TriggerRequest {
+            function_id: "llm::route".to_string(),
+            payload: json!({
             "message": &req.message,
             "toolCount": tools.as_array().map(|a| a.len()).unwrap_or(0),
             "config": config.as_ref().and_then(|c| c.model.as_ref()),
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let scan_result = iii
-        .trigger_v0("security::scan_injection", json!({ "text": &req.message }))
+        .trigger(TriggerRequest {
+            function_id: "security::scan_injection".to_string(),
+            payload: json!({ "text": &req.message }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!({ "safe": true, "riskScore": 0.0 }));
     let risk_score = scan_result["riskScore"].as_f64().unwrap_or(0.0);
@@ -280,12 +207,17 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
     messages.push(json!({ "role": "user", "content": &req.message }));
 
     let mut response: Value = iii
-        .trigger_v0("llm::complete", json!({
+        .trigger(TriggerRequest {
+            function_id: "llm::complete".to_string(),
+            payload: json!({
             "model": model,
             "systemPrompt": system_prompt,
             "messages": messages,
             "tools": tools,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -304,11 +236,16 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
 
         let mut tool_results = Vec::new();
         for tc in &calls {
-            let cap_check = iii.trigger_v0("security::check_capability", json!({
+            let cap_check = iii.trigger(TriggerRequest {
+                function_id: "security::check_capability".to_string(),
+                payload: json!({
                 "agentId": &req.agent_id,
                 "capability": tc.id.split("::").next().unwrap_or(""),
                 "resource": &tc.id,
-            })).await;
+            }),
+                action: None,
+                timeout_ms: None,
+            }).await;
 
             if cap_check.is_err() {
                 tool_results.push(json!({
@@ -318,7 +255,12 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
                 continue;
             }
 
-            match iii.trigger_v0(&tc.id, tc.arguments.clone()).await {
+            match iii.trigger(TriggerRequest {
+                function_id: tc.id.to_string(),
+                payload: tc.arguments.clone(),
+                action: None,
+                timeout_ms: None,
+            }).await {
                 Ok(result) => {
                     tool_results.push(json!({
                         "toolCallId": tc.call_id,
@@ -340,12 +282,17 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         }
 
         response = iii
-            .trigger_v0("llm::complete", json!({
+            .trigger(TriggerRequest {
+                function_id: "llm::complete".to_string(),
+                payload: json!({
                 "model": model,
                 "systemPrompt": system_prompt,
                 "messages": messages,
                 "tools": tools,
-            }))
+            }),
+                action: None,
+                timeout_ms: None,
+            })
             .await
             .map_err(|e| IIIError::Handler(e.to_string()))?;
     }
@@ -353,29 +300,62 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
     let session_id = req.session_id
         .unwrap_or_else(|| format!("default:{}", req.agent_id));
 
-    let _ = iii.trigger_void("memory::store", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "agentId": &req.agent_id,
         "sessionId": &session_id,
         "role": "user",
         "content": &req.message,
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "memory::store".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
-    let _ = iii.trigger_void("memory::store", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "agentId": &req.agent_id,
         "sessionId": &session_id,
         "role": "assistant",
         "content": response.get("content").and_then(|v| v.as_str()).unwrap_or(""),
         "tokenUsage": response.get("usage"),
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "memory::store".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
-    let _ = iii.trigger_void("state::update", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "scope": "metering",
         "key": &req.agent_id,
         "operations": [
             { "type": "increment", "path": "totalTokens", "value": response["usage"]["total"] },
             { "type": "increment", "path": "invocations", "value": 1 },
         ],
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "state::update".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(json!({
         "content": response.get("content").and_then(|v| v.as_str()).unwrap_or(""),
@@ -388,7 +368,12 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
 
 async fn list_tools(iii: &III, agent_id: &str) -> Result<Value, IIIError> {
     let config: Option<AgentConfig> = iii
-        .trigger_v0("state::get", json!({ "scope": "agents", "key": agent_id }))
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": "agents", "key": agent_id }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok()
         .and_then(|v| serde_json::from_value(v).ok());
@@ -406,7 +391,12 @@ async fn list_tools(iii: &III, agent_id: &str) -> Result<Value, IIIError> {
         .collect();
 
     let all_functions: Value = iii
-        .trigger_v0("engine::functions::list", json!({}))
+        .trigger(TriggerRequest {
+            function_id: "engine::functions::list".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -1311,7 +1301,9 @@ mod tests {
 async fn create_agent(iii: &III, config: AgentConfig) -> Result<Value, IIIError> {
     let agent_id = config.id.clone().unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": "agents",
         "key": &agent_id,
         "value": {
@@ -1325,14 +1317,28 @@ async fn create_agent(iii: &III, config: AgentConfig) -> Result<Value, IIIError>
             "tags": &config.tags,
             "createdAt": std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis(),
         },
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "agent.lifecycle",
         "data": { "type": "created", "agentId": &agent_id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(json!({ "agentId": agent_id }))
 }

--- a/workers/agent-core/src/main.rs
+++ b/workers/agent-core/src/main.rs
@@ -16,7 +16,8 @@ const MAX_ITERATIONS: u32 = 50;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/bridge/src/main.rs
+++ b/workers/bridge/src/main.rs
@@ -1,128 +1,9 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use dashmap::DashMap;
 use std::sync::Arc;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -173,11 +54,16 @@ async fn register_runtime(iii: &III, req: RegisterRuntimeRequest) -> Result<Valu
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": runtimes_scope(),
         "key": &id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -190,10 +76,15 @@ async fn invoke_runtime(
     active_runs: &Arc<DashMap<String, tokio::task::JoinHandle<()>>>,
 ) -> Result<Value, IIIError> {
     let config_val = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": runtimes_scope(),
             "key": &req.runtime_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -216,11 +107,16 @@ async fn invoke_runtime(
     };
 
     let run_val = serde_json::to_value(&run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": runs_scope(),
         "key": &run_id,
         "value": run_val,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -249,17 +145,33 @@ async fn invoke_runtime(
         };
 
         let val = serde_json::to_value(&finished_run).unwrap();
-        let _ = iii_bg.trigger_v0("state::set", json!({
+        let _ = iii_bg.trigger(TriggerRequest {
+            function_id: "state::set".to_string(),
+            payload: json!({
             "scope": runs_scope(),
             "key": &run_id_bg,
             "value": val,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await;
 
-        let _ = iii_bg.trigger_void("publish", json!({
+        let _ = {
+            let _iii = iii_bg.clone();
+            let _payload = json!({
             "topic": "bridge.run.completed",
             "data": { "runId": run_id_bg, "status": format!("{:?}", finished_run.status).to_lowercase() },
-        }));
+        });
+            tokio::spawn(async move {
+                let _ = _iii.trigger(TriggerRequest {
+                    function_id: "publish".to_string(),
+                    payload: _payload,
+                    action: None,
+                    timeout_ms: None,
+                }).await;
+            });
+        };
     });
 
     active_runs.insert(run_id.clone(), handle);
@@ -278,12 +190,17 @@ async fn execute_runtime(iii: &III, config: &RuntimeConfig, context: &Value, tim
             let url = config.url.as_deref().ok_or_else(|| IIIError::Handler("missing url".into()))?;
 
             let result = iii
-                .trigger_v0("http::post", json!({
+                .trigger(TriggerRequest {
+                    function_id: "http::post".to_string(),
+                    payload: json!({
                     "url": url,
                     "body": context,
                     "headers": config.headers,
                     "timeoutMs": timeout_secs * 1000,
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await
                 .map_err(|e| IIIError::Handler(format!("http invoke failed: {e}")))?;
 
@@ -353,12 +270,17 @@ async fn cancel_run(
     if let Some((_, handle)) = active_runs.remove(&req.run_id) {
         handle.abort();
 
-        let _ = iii.trigger_v0("state::update", json!({
+        let _ = iii.trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
             "scope": runs_scope(),
             "key": &req.run_id,
             "path": "status",
             "value": "cancelled",
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await;
 
         Ok(json!({ "cancelled": true, "runId": req.run_id }))
@@ -368,16 +290,26 @@ async fn cancel_run(
 }
 
 async fn list_runtimes(iii: &III) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::list", json!({ "scope": runtimes_scope() }))
+    iii.trigger(TriggerRequest {
+        function_id: "state::list".to_string(),
+        payload: json!({ "scope": runtimes_scope() }),
+        action: None,
+        timeout_ms: None,
+    })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
 async fn get_run(iii: &III, run_id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::get", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::get".to_string(),
+        payload: json!({
         "scope": runs_scope(),
         "key": run_id,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
@@ -390,25 +322,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let active_runs: Arc<DashMap<String, tokio::task::JoinHandle<()>>> = Arc::new(DashMap::new());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "bridge::register",
-        "Register an external agent runtime",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("bridge::register", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: RegisterRuntimeRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 register_runtime(&iii, req).await
             }
-        },
+        })
+        .description("Register an external agent runtime"),
     );
 
     let iii_clone = iii.clone();
     let runs_clone = active_runs.clone();
-    iii.register_function_with_description(
-        "bridge::invoke",
-        "Invoke an agent through its runtime bridge",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("bridge::invoke", move |input: Value| {
             let iii = iii_clone.clone();
             let runs = runs_clone.clone();
             async move {
@@ -416,15 +345,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 invoke_runtime(&iii, req, &runs).await
             }
-        },
+        })
+        .description("Invoke an agent through its runtime bridge"),
     );
 
     let iii_clone = iii.clone();
     let runs_clone = active_runs.clone();
-    iii.register_function_with_description(
-        "bridge::cancel",
-        "Cancel a running bridge invocation",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("bridge::cancel", move |input: Value| {
             let iii = iii_clone.clone();
             let runs = runs_clone.clone();
             async move {
@@ -432,24 +360,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 cancel_run(&runs, &iii, req).await
             }
-        },
+        })
+        .description("Cancel a running bridge invocation"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "bridge::list",
-        "List registered runtimes",
-        move |_: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("bridge::list", move |_: Value| {
             let iii = iii_clone.clone();
             async move { list_runtimes(&iii).await }
-        },
+        })
+        .description("List registered runtimes"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "bridge::run",
-        "Get status of a bridge run",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("bridge::run", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let run_id = input["runId"]
@@ -457,14 +383,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing runId".into()))?;
                 get_run(&iii, run_id).await
             }
-        },
+        })
+        .description("Get status of a bridge run"),
     );
 
-    iii.register_trigger_v0("http", "bridge::register", json!({ "method": "POST", "path": "/api/bridge/runtimes" }))?;
-    iii.register_trigger_v0("http", "bridge::invoke", json!({ "method": "POST", "path": "/api/bridge/invoke" }))?;
-    iii.register_trigger_v0("http", "bridge::cancel", json!({ "method": "POST", "path": "/api/bridge/cancel" }))?;
-    iii.register_trigger_v0("http", "bridge::list", json!({ "method": "GET", "path": "/api/bridge/runtimes" }))?;
-    iii.register_trigger_v0("http", "bridge::run", json!({ "method": "GET", "path": "/api/bridge/runs/:runId" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "bridge::register".to_string(),
+        config: json!({ "method": "POST", "path": "/api/bridge/runtimes" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "bridge::invoke".to_string(),
+        config: json!({ "method": "POST", "path": "/api/bridge/invoke" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "bridge::cancel".to_string(),
+        config: json!({ "method": "POST", "path": "/api/bridge/cancel" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "bridge::list".to_string(),
+        config: json!({ "method": "GET", "path": "/api/bridge/runtimes" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "bridge::run".to_string(),
+        config: json!({ "method": "GET", "path": "/api/bridge/runs/:runId" }),
+        metadata: None,
+    })?;
 
     tracing::info!("bridge worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/bridge/src/main.rs
+++ b/workers/bridge/src/main.rs
@@ -318,7 +318,8 @@ async fn get_run(iii: &III, run_id: &str) -> Result<Value, IIIError> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
     let active_runs: Arc<DashMap<String, tokio::task::JoinHandle<()>>> = Arc::new(DashMap::new());
 
     let iii_clone = iii.clone();

--- a/workers/council/src/main.rs
+++ b/workers/council/src/main.rs
@@ -1,127 +1,8 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -142,7 +23,12 @@ fn activity_scope(realm_id: &str) -> String {
 
 async fn get_prev_hash(iii: &III, realm_id: &str) -> String {
     let entries = iii
-        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": activity_scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
@@ -192,11 +78,16 @@ async fn log_activity(iii: &III, req: LogActivityRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&entry).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": activity_scope(&req.realm_id),
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -223,11 +114,16 @@ async fn submit_proposal(iii: &III, req: SubmitProposalRequest) -> Result<Value,
 
     let value = serde_json::to_value(&proposal).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": proposals_scope(&req.realm_id),
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -242,10 +138,21 @@ async fn submit_proposal(iii: &III, req: SubmitProposalRequest) -> Result<Value,
     })
     .await;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "council.proposal",
         "data": { "type": "submitted", "proposalId": proposal.id, "realmId": req.realm_id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&proposal).unwrap())
 }
@@ -254,7 +161,12 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
     let realm_id = &req.realm_id;
 
     let val = iii
-        .trigger_v0("state::get", json!({ "scope": proposals_scope(realm_id), "key": &req.id }))
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": proposals_scope(realm_id), "key": &req.id }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -279,11 +191,16 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
 
     let value = serde_json::to_value(&proposal).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": proposals_scope(realm_id),
         "key": proposal.id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -298,21 +215,37 @@ async fn decide_proposal(iii: &III, req: DecideProposalRequest) -> Result<Value,
     })
     .await;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "council.proposal",
         "data": {
             "type": if req.approved { "approved" } else { "rejected" },
             "proposalId": proposal.id,
             "realmId": realm_id,
         },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&proposal).unwrap())
 }
 
 async fn list_proposals(iii: &III, realm_id: &str, status_filter: Option<ProposalStatus>) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": proposals_scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": proposals_scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -341,12 +274,17 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
     };
 
     let _ = iii
-        .trigger_v0("state::update", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
             "scope": "agents",
             "key": &req.target_agent_id,
             "path": "status",
             "value": new_status,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await;
 
     let _ = log_activity(iii, LogActivityRequest {
@@ -360,7 +298,9 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
     })
     .await;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "council.override",
         "data": {
             "action": req.action,
@@ -368,7 +308,16 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
             "operatorId": req.operator_id,
             "realmId": req.realm_id,
         },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(json!({
         "overridden": true,
@@ -379,7 +328,12 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
 
 async fn get_activity_log(iii: &III, realm_id: &str, limit: usize) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": activity_scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -403,7 +357,12 @@ async fn get_activity_log(iii: &III, realm_id: &str, limit: usize) -> Result<Val
 
 async fn verify_activity_chain(iii: &III, realm_id: &str) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": activity_scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": activity_scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -447,38 +406,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::submit",
-        "Submit a proposal for council review",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::submit", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: SubmitProposalRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 submit_proposal(&iii, req).await
             }
-        },
+        })
+        .description("Submit a proposal for council review"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::decide",
-        "Approve or reject a proposal",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::decide", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: DecideProposalRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 decide_proposal(&iii, req).await
             }
-        },
+        })
+        .description("Approve or reject a proposal"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::proposals",
-        "List proposals for a realm",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::proposals", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -489,42 +444,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .and_then(|v| serde_json::from_value(v.clone()).ok());
                 list_proposals(&iii, realm_id, status).await
             }
-        },
+        })
+        .description("List proposals for a realm"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::override",
-        "Override agent state (pause/resume/terminate)",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::override", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: OverrideRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 override_agent(&iii, req).await
             }
-        },
+        })
+        .description("Override agent state (pause/resume/terminate)"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::activity",
-        "Log an activity entry",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::activity", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: LogActivityRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 log_activity(&iii, req).await
             }
-        },
+        })
+        .description("Log an activity entry"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::activity_log",
-        "Get recent activity log entries",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::activity_log", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -533,14 +485,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let limit = input["limit"].as_u64().unwrap_or(50) as usize;
                 get_activity_log(&iii, realm_id, limit).await
             }
-        },
+        })
+        .description("Get recent activity log entries"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "council::verify",
-        "Verify integrity of activity chain",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("council::verify", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -548,17 +499,53 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing realmId".into()))?;
                 verify_activity_chain(&iii, realm_id).await
             }
-        },
+        })
+        .description("Verify integrity of activity chain"),
     );
 
-    iii.register_trigger_v0("http", "council::submit", json!({ "method": "POST", "path": "/api/council/proposals" }))?;
-    iii.register_trigger_v0("http", "council::decide", json!({ "method": "POST", "path": "/api/council/proposals/:id/decide" }))?;
-    iii.register_trigger_v0("http", "council::proposals", json!({ "method": "GET", "path": "/api/council/proposals/:realmId" }))?;
-    iii.register_trigger_v0("http", "council::override", json!({ "method": "POST", "path": "/api/council/override" }))?;
-    iii.register_trigger_v0("http", "council::activity_log", json!({ "method": "GET", "path": "/api/council/activity/:realmId" }))?;
-    iii.register_trigger_v0("http", "council::verify", json!({ "method": "GET", "path": "/api/council/verify/:realmId" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::submit".to_string(),
+        config: json!({ "method": "POST", "path": "/api/council/proposals" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::decide".to_string(),
+        config: json!({ "method": "POST", "path": "/api/council/proposals/:id/decide" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::proposals".to_string(),
+        config: json!({ "method": "GET", "path": "/api/council/proposals/:realmId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::override".to_string(),
+        config: json!({ "method": "POST", "path": "/api/council/override" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::activity_log".to_string(),
+        config: json!({ "method": "GET", "path": "/api/council/activity/:realmId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "council::verify".to_string(),
+        config: json!({ "method": "GET", "path": "/api/council/verify/:realmId" }),
+        metadata: None,
+    })?;
 
-    iii.register_trigger_v0("subscribe", "council::activity", json!({ "topic": "council.audit" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "subscribe".to_string(),
+        function_id: "council::activity".to_string(),
+        config: json!({ "topic": "council.audit" }),
+        metadata: None,
+    })?;
 
     tracing::info!("council worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/council/src/main.rs
+++ b/workers/council/src/main.rs
@@ -273,19 +273,19 @@ async fn override_agent(iii: &III, req: OverrideRequest) -> Result<Value, IIIErr
         other => return Err(IIIError::Handler(format!("unknown override action: {other}"))),
     };
 
-    let _ = iii
-        .trigger(TriggerRequest {
-            function_id: "state::update".to_string(),
-            payload: json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::update".to_string(),
+        payload: json!({
             "scope": "agents",
             "key": &req.target_agent_id,
             "path": "status",
             "value": new_status,
         }),
-            action: None,
-            timeout_ms: None,
-        })
-        .await;
+        action: None,
+        timeout_ms: None,
+    })
+    .await
+    .map_err(|e| IIIError::Handler(format!("failed to update agent state: {e}")))?;
 
     let _ = log_activity(iii, LogActivityRequest {
         realm_id: req.realm_id.clone(),
@@ -403,7 +403,8 @@ async fn verify_activity_chain(iii: &III, realm_id: &str) -> Result<Value, IIIEr
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/directive/src/main.rs
+++ b/workers/directive/src/main.rs
@@ -235,7 +235,8 @@ async fn get_ancestry(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIE
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/directive/src/main.rs
+++ b/workers/directive/src/main.rs
@@ -1,126 +1,7 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -138,7 +19,12 @@ fn scope(realm_id: &str) -> String {
 async fn create_directive(iii: &III, req: CreateDirectiveRequest) -> Result<Value, IIIError> {
     if let Some(ref parent_id) = req.parent_id {
         let parent = iii
-            .trigger_v0("state::get", json!({ "scope": scope(&req.realm_id), "key": parent_id }))
+            .trigger(TriggerRequest {
+                function_id: "state::get".to_string(),
+                payload: json!({ "scope": scope(&req.realm_id), "key": parent_id }),
+                action: None,
+                timeout_ms: None,
+            })
             .await
             .map_err(|e| IIIError::Handler(format!("parent directive not found: {e}")))?;
 
@@ -167,34 +53,60 @@ async fn create_directive(iii: &III, req: CreateDirectiveRequest) -> Result<Valu
 
     let value = serde_json::to_value(&directive).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": scope(&req.realm_id),
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "directive.lifecycle",
         "data": { "type": "created", "directiveId": directive.id, "realmId": directive.realm_id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&directive).unwrap())
 }
 
 async fn get_directive(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::get", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::get".to_string(),
+        payload: json!({
         "scope": scope(realm_id),
         "key": id,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
 async fn list_directives(iii: &III, req: ListDirectivesRequest) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": scope(&req.realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope(&req.realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -221,7 +133,12 @@ async fn list_directives(iii: &III, req: ListDirectivesRequest) -> Result<Value,
 async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Value, IIIError> {
     let realm_id = &req.realm_id;
     let existing = iii
-        .trigger_v0("state::get", json!({ "scope": scope(realm_id), "key": &req.id }))
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": scope(realm_id), "key": &req.id }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -249,12 +166,17 @@ async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Valu
 
     let value = serde_json::to_value(&d).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": scope(realm_id),
         "key": d.id,
         "value": value,
         "expectedVersion": prev_version,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -263,7 +185,12 @@ async fn update_directive(iii: &III, req: UpdateDirectiveRequest) -> Result<Valu
 
 async fn get_ancestry(iii: &III, realm_id: &str, id: &str) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -311,24 +238,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "directive::create",
-        "Create a strategic directive",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("directive::create", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CreateDirectiveRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 create_directive(&iii, req).await
             }
-        },
+        })
+        .description("Create a strategic directive"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "directive::get",
-        "Get directive by ID",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("directive::get", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -339,42 +263,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing id".into()))?;
                 get_directive(&iii, realm_id, id).await
             }
-        },
+        })
+        .description("Get directive by ID"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "directive::list",
-        "List directives with filtering",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("directive::list", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ListDirectivesRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 list_directives(&iii, req).await
             }
-        },
+        })
+        .description("List directives with filtering"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "directive::update",
-        "Update directive status or details",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("directive::update", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: UpdateDirectiveRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 update_directive(&iii, req).await
             }
-        },
+        })
+        .description("Update directive status or details"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "directive::ancestry",
-        "Trace directive ancestry to root",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("directive::ancestry", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -385,14 +306,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing id".into()))?;
                 get_ancestry(&iii, realm_id, id).await
             }
-        },
+        })
+        .description("Trace directive ancestry to root"),
     );
 
-    iii.register_trigger_v0("http", "directive::create", json!({ "method": "POST", "path": "/api/directives" }))?;
-    iii.register_trigger_v0("http", "directive::get", json!({ "method": "GET", "path": "/api/directives/:realmId/:id" }))?;
-    iii.register_trigger_v0("http", "directive::list", json!({ "method": "GET", "path": "/api/directives/:realmId" }))?;
-    iii.register_trigger_v0("http", "directive::update", json!({ "method": "PATCH", "path": "/api/directives/:realmId/:id" }))?;
-    iii.register_trigger_v0("http", "directive::ancestry", json!({ "method": "GET", "path": "/api/directives/:realmId/:id/ancestry" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "directive::create".to_string(),
+        config: json!({ "method": "POST", "path": "/api/directives" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "directive::get".to_string(),
+        config: json!({ "method": "GET", "path": "/api/directives/:realmId/:id" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "directive::list".to_string(),
+        config: json!({ "method": "GET", "path": "/api/directives/:realmId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "directive::update".to_string(),
+        config: json!({ "method": "PATCH", "path": "/api/directives/:realmId/:id" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "directive::ancestry".to_string(),
+        config: json!({ "method": "GET", "path": "/api/directives/:realmId/:id/ancestry" }),
+        metadata: None,
+    })?;
 
     tracing::info!("directive worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/hierarchy/src/main.rs
+++ b/workers/hierarchy/src/main.rs
@@ -227,7 +227,8 @@ async fn remove_node(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value,
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/hierarchy/src/main.rs
+++ b/workers/hierarchy/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -7,125 +7,6 @@ mod types;
 
 use types::{ChainRequest, FindByCapabilityRequest, HierarchyNode, SetHierarchyRequest, TreeNode, TreeRequest};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -156,11 +37,16 @@ async fn set_node(iii: &III, req: SetHierarchyRequest) -> Result<Value, IIIError
 
     let value = serde_json::to_value(&node).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": scope(&req.realm_id),
         "key": node.agent_id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -192,7 +78,12 @@ fn would_create_cycle(nodes: &[HierarchyNode], agent_id: &str, new_parent: &str)
 
 async fn load_all(iii: &III, realm_id: &str) -> Result<Vec<HierarchyNode>, IIIError> {
     let result = iii
-        .trigger_v0("state::list", json!({ "scope": scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -317,10 +208,15 @@ async fn get_chain(iii: &III, req: ChainRequest) -> Result<Value, IIIError> {
 }
 
 async fn remove_node(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::delete", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::delete".to_string(),
+        payload: json!({
         "scope": scope(realm_id),
         "key": agent_id,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -334,66 +230,60 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "hierarchy::set",
-        "Set agent position in hierarchy",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("hierarchy::set", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: SetHierarchyRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 set_node(&iii, req).await
             }
-        },
+        })
+        .description("Set agent position in hierarchy"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "hierarchy::tree",
-        "Get full org tree for a realm",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("hierarchy::tree", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: TreeRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 get_tree(&iii, req).await
             }
-        },
+        })
+        .description("Get full org tree for a realm"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "hierarchy::find",
-        "Find agents by capability",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("hierarchy::find", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: FindByCapabilityRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 find_by_capability(&iii, req).await
             }
-        },
+        })
+        .description("Find agents by capability"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "hierarchy::chain",
-        "Get chain of command for an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("hierarchy::chain", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ChainRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 get_chain(&iii, req).await
             }
-        },
+        })
+        .description("Get chain of command for an agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "hierarchy::remove",
-        "Remove agent from hierarchy",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("hierarchy::remove", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -404,14 +294,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing agentId".into()))?;
                 remove_node(&iii, realm_id, agent_id).await
             }
-        },
+        })
+        .description("Remove agent from hierarchy"),
     );
 
-    iii.register_trigger_v0("http", "hierarchy::set", json!({ "method": "POST", "path": "/api/hierarchy" }))?;
-    iii.register_trigger_v0("http", "hierarchy::tree", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/tree" }))?;
-    iii.register_trigger_v0("http", "hierarchy::find", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/find" }))?;
-    iii.register_trigger_v0("http", "hierarchy::chain", json!({ "method": "GET", "path": "/api/hierarchy/:realmId/chain/:agentId" }))?;
-    iii.register_trigger_v0("http", "hierarchy::remove", json!({ "method": "DELETE", "path": "/api/hierarchy/:realmId/:agentId" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "hierarchy::set".to_string(),
+        config: json!({ "method": "POST", "path": "/api/hierarchy" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "hierarchy::tree".to_string(),
+        config: json!({ "method": "GET", "path": "/api/hierarchy/:realmId/tree" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "hierarchy::find".to_string(),
+        config: json!({ "method": "GET", "path": "/api/hierarchy/:realmId/find" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "hierarchy::chain".to_string(),
+        config: json!({ "method": "GET", "path": "/api/hierarchy/:realmId/chain/:agentId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "hierarchy::remove".to_string(),
+        config: json!({ "method": "DELETE", "path": "/api/hierarchy/:realmId/:agentId" }),
+        metadata: None,
+    })?;
 
     tracing::info!("hierarchy worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/ledger/src/main.rs
+++ b/workers/ledger/src/main.rs
@@ -1,126 +1,7 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -147,10 +28,15 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
         .to_string();
 
     let existing = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": budget_scope(&req.realm_id),
             "key": &key,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok()
         .and_then(|v| serde_json::from_value::<Budget>(v).ok());
@@ -176,11 +62,16 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
 
     let value = serde_json::to_value(&budget).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": budget_scope(&req.realm_id),
         "key": key,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -189,18 +80,28 @@ async fn set_budget(iii: &III, req: SetBudgetRequest) -> Result<Value, IIIError>
 
 async fn check_budget(iii: &III, req: CheckBudgetRequest) -> Result<Value, IIIError> {
     let agent_budget = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": budget_scope(&req.realm_id),
             "key": &req.agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
     let realm_budget = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": budget_scope(&req.realm_id),
             "key": "realm",
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
@@ -263,7 +164,9 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
         serde_json::from_value(check).map_err(|e| IIIError::Handler(e.to_string()))?;
 
     if !check_result.allowed {
-        let _ = iii.trigger_void("publish", json!({
+        let _ = {
+            let _iii = iii.clone();
+            let _payload = json!({
             "topic": "ledger.alert",
             "data": {
                 "type": "hard_limit_reached",
@@ -272,11 +175,20 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
                 "spentCents": check_result.spent_cents,
                 "limitCents": check_result.limit_cents,
             },
-        }));
+        });
+            tokio::spawn(async move {
+                let _ = _iii.trigger(TriggerRequest {
+                    function_id: "publish".to_string(),
+                    payload: _payload,
+                    action: None,
+                    timeout_ms: None,
+                }).await;
+            });
+        };
 
-        let _ = iii.trigger_v0(
-            "council::activity",
-            json!({
+        let _ = iii.trigger(TriggerRequest {
+            function_id: "council::activity".to_string(),
+            payload: json!({
                 "realmId": req.realm_id,
                 "actorKind": "system",
                 "actorId": "ledger",
@@ -285,7 +197,9 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
                 "entityId": req.agent_id,
                 "details": { "spentCents": check_result.spent_cents, "limitCents": check_result.limit_cents },
             }),
-        ).await;
+            action: None,
+            timeout_ms: None,
+        }).await;
 
         return Err(IIIError::Handler(format!(
             "agent {} exceeded budget: {}/{}",
@@ -309,19 +223,29 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&event).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": spend_scope(&req.realm_id),
         "key": event.id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let budget_val = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": budget_scope(&req.realm_id),
             "key": &req.agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
@@ -334,17 +258,24 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
             let updated = serde_json::to_value(&budget).map_err(|e| IIIError::Handler(e.to_string()))?;
             let _ = iii
-                .trigger_v0("state::set", json!({
+                .trigger(TriggerRequest {
+                    function_id: "state::set".to_string(),
+                    payload: json!({
                     "scope": budget_scope(&req.realm_id),
                     "key": &req.agent_id,
                     "value": updated,
                     "expectedVersion": prev_version,
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await;
 
             let utilization = (budget.spent_cents as f64 / budget.monthly_cents as f64) * 100.0;
             if utilization >= budget.soft_threshold * 100.0 && utilization < 100.0 {
-                let _ = iii.trigger_void("publish", json!({
+                let _ = {
+                    let _iii = iii.clone();
+                    let _payload = json!({
                     "topic": "ledger.alert",
                     "data": {
                         "type": "soft_threshold",
@@ -352,7 +283,16 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
                         "agentId": req.agent_id,
                         "utilizationPct": utilization,
                     },
-                }));
+                });
+                    tokio::spawn(async move {
+                        let _ = _iii.trigger(TriggerRequest {
+                            function_id: "publish".to_string(),
+                            payload: _payload,
+                            action: None,
+                            timeout_ms: None,
+                        }).await;
+                    });
+                };
             }
         }
     }
@@ -362,7 +302,12 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
 
 async fn get_summary(iii: &III, req: SummaryRequest) -> Result<Value, IIIError> {
     let events = iii
-        .trigger_v0("state::list", json!({ "scope": spend_scope(&req.realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": spend_scope(&req.realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -409,67 +354,88 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "ledger::set_budget",
-        "Set budget for realm or agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("ledger::set_budget", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: SetBudgetRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 set_budget(&iii, req).await
             }
-        },
+        })
+        .description("Set budget for realm or agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "ledger::check",
-        "Check if agent is within budget",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("ledger::check", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CheckBudgetRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 check_budget(&iii, req).await
             }
-        },
+        })
+        .description("Check if agent is within budget"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "ledger::spend",
-        "Record a spend event and enforce budget",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("ledger::spend", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: RecordSpendRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 record_spend(&iii, req).await
             }
-        },
+        })
+        .description("Record a spend event and enforce budget"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "ledger::summary",
-        "Get spend summary with breakdowns",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("ledger::summary", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: SummaryRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 get_summary(&iii, req).await
             }
-        },
+        })
+        .description("Get spend summary with breakdowns"),
     );
 
-    iii.register_trigger_v0("http", "ledger::set_budget", json!({ "method": "POST", "path": "/api/ledger/budget" }))?;
-    iii.register_trigger_v0("http", "ledger::check", json!({ "method": "GET", "path": "/api/ledger/check/:realmId/:agentId" }))?;
-    iii.register_trigger_v0("http", "ledger::spend", json!({ "method": "POST", "path": "/api/ledger/spend" }))?;
-    iii.register_trigger_v0("http", "ledger::summary", json!({ "method": "GET", "path": "/api/ledger/summary/:realmId" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "ledger::set_budget".to_string(),
+        config: json!({ "method": "POST", "path": "/api/ledger/budget" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "ledger::check".to_string(),
+        config: json!({ "method": "GET", "path": "/api/ledger/check/:realmId/:agentId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "ledger::spend".to_string(),
+        config: json!({ "method": "POST", "path": "/api/ledger/spend" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "ledger::summary".to_string(),
+        config: json!({ "method": "GET", "path": "/api/ledger/summary/:realmId" }),
+        metadata: None,
+    })?;
 
-    iii.register_trigger_v0("subscribe", "ledger::spend", json!({ "topic": "cost.incurred" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "subscribe".to_string(),
+        function_id: "ledger::spend".to_string(),
+        config: json!({ "topic": "cost.incurred" }),
+        metadata: None,
+    })?;
 
     tracing::info!("ledger worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/ledger/src/main.rs
+++ b/workers/ledger/src/main.rs
@@ -271,8 +271,12 @@ async fn record_spend(iii: &III, req: RecordSpendRequest) -> Result<Value, IIIEr
                 })
                 .await;
 
-            let utilization = (budget.spent_cents as f64 / budget.monthly_cents as f64) * 100.0;
-            if utilization >= budget.soft_threshold * 100.0 && utilization < 100.0 {
+            let utilization = if budget.monthly_cents > 0 {
+                (budget.spent_cents as f64 / budget.monthly_cents as f64) * 100.0
+            } else {
+                0.0
+            };
+            if budget.monthly_cents > 0 && utilization >= budget.soft_threshold * 100.0 && utilization < 100.0 {
                 let _ = {
                     let _iii = iii.clone();
                     let _payload = json!({
@@ -351,7 +355,8 @@ async fn get_summary(iii: &III, req: SummaryRequest) -> Result<Value, IIIError> 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/llm-router/src/main.rs
+++ b/workers/llm-router/src/main.rs
@@ -286,7 +286,8 @@ async fn providers_handler(state: Arc<RouterState>, _input: Value) -> Result<Val
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let state = Arc::new(RouterState {
         usage: DashMap::new(),

--- a/workers/memory/src/main.rs
+++ b/workers/memory/src/main.rs
@@ -1,129 +1,10 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -151,103 +32,109 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::store",
-        "Store a memory entry with dedup",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::store", move |input: Value| {
             let iii = iii_ref.clone();
             async move { store_memory(&iii, input).await }
-        },
+        })
+        .description("Store a memory entry with dedup"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::recall",
-        "Hybrid semantic + keyword + recency search",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::recall", move |input: Value| {
             let iii = iii_ref.clone();
             async move { recall_memory(&iii, input).await }
-        },
+        })
+        .description("Hybrid semantic + keyword + recency search"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::kg::add",
-        "Add knowledge graph entity with bidirectional relations",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::kg::add", move |input: Value| {
             let iii = iii_ref.clone();
             async move { kg_add(&iii, input).await }
-        },
+        })
+        .description("Add knowledge graph entity with bidirectional relations"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::kg::query",
-        "Traverse knowledge graph from entity",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::kg::query", move |input: Value| {
             let iii = iii_ref.clone();
             async move { kg_query(&iii, input).await }
-        },
+        })
+        .description("Traverse knowledge graph from entity"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::evict",
-        "Evict stale and low-importance memories",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::evict", move |input: Value| {
             let iii = iii_ref.clone();
             async move { evict_memories(&iii, input).await }
-        },
+        })
+        .description("Evict stale and low-importance memories"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::consolidate",
-        "Decay confidence on unaccessed memories",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::consolidate", move |input: Value| {
             let iii = iii_ref.clone();
             async move { consolidate(&iii, input).await }
-        },
+        })
+        .description("Decay confidence on unaccessed memories"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::session::list",
-        "List sessions for an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::session::list", move |input: Value| {
             let iii = iii_ref.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("default");
-                iii.trigger_v0("state::list", json!({ "scope": format!("sessions:{}", agent_id) }))
+                iii.trigger(TriggerRequest {
+                    function_id: "state::list".to_string(),
+                    payload: json!({ "scope": format!("sessions:{}", agent_id) }),
+                    action: None,
+                    timeout_ms: None,
+                })
                     .await
                     .map_err(|e| IIIError::Handler(e.to_string()))
             }
-        },
+        })
+        .description("List sessions for an agent"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::session::compact",
-        "Compact session via LLM summarization",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::session::compact", move |input: Value| {
             let iii = iii_ref.clone();
             async move { compact_session(&iii, input).await }
-        },
+        })
+        .description("Compact session via LLM summarization"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "memory::session::repair",
-        "7-phase session validation and repair",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("memory::session::repair", move |input: Value| {
             let iii = iii_ref.clone();
             async move { repair_session(&iii, input).await }
-        },
+        })
+        .description("7-phase session validation and repair"),
     );
 
-    iii.register_trigger_v0("cron", "memory::consolidate", json!({ "expression": "0 */6 * * *" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "cron".to_string(),
+        function_id: "memory::consolidate".to_string(),
+        config: json!({ "expression": "0 */6 * * *" }),
+        metadata: None,
+    })?;
 
-    iii.register_trigger_v0("cron", "memory::evict", json!({ "expression": "0 3 * * *" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "cron".to_string(),
+        function_id: "memory::evict".to_string(),
+        config: json!({ "expression": "0 3 * * *" }),
+        metadata: None,
+    })?;
 
     tracing::info!("memory worker started");
     tokio::signal::ctrl_c().await?;
@@ -268,10 +155,15 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     };
 
     let existing: Option<Value> = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("memory:{}", agent_id),
             "key": &hash,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
@@ -283,7 +175,12 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     let now = now_ms();
 
     let embedding: Option<Vec<f64>> = iii
-        .trigger_v0("embedding::generate", json!({ "text": content }))
+        .trigger(TriggerRequest {
+            function_id: "embedding::generate".to_string(),
+            payload: json!({ "text": content }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok()
         .and_then(|v| {
@@ -308,27 +205,42 @@ async fn store_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
         "lastAccessed": now,
     });
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": format!("memory:{}", agent_id),
         "key": &id,
         "value": &entry,
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": format!("memory:{}", agent_id),
         "key": &hash,
         "value": { "id": &id, "timestamp": now },
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     if let Some(sid) = &session_id {
-        let _ = iii.trigger_v0("state::update", json!({
+        let _ = iii.trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
             "scope": format!("sessions:{}", agent_id),
             "key": sid,
             "operations": [
                 { "type": "merge", "path": "messages", "value": [{ "id": &id, "role": role, "timestamp": now }] },
                 { "type": "set", "path": "updatedAt", "value": now },
             ],
-        })).await;
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await;
     }
 
     Ok(json!({ "id": id, "stored": true }))
@@ -340,7 +252,12 @@ async fn recall_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     let limit = input["limit"].as_u64().unwrap_or(10) as usize;
 
     let entries: Value = iii
-        .trigger_v0("state::list", json!({ "scope": format!("memory:{}", agent_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": format!("memory:{}", agent_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -362,7 +279,12 @@ async fn recall_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let query_embedding: Option<Vec<f64>> = iii
-        .trigger_v0("embedding::generate", json!({ "text": query }))
+        .trigger(TriggerRequest {
+            function_id: "embedding::generate".to_string(),
+            payload: json!({ "text": query }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok()
         .and_then(|v| {
@@ -409,14 +331,25 @@ async fn recall_memory(iii: &III, input: Value) -> Result<Value, IIIError> {
         .into_iter()
         .take(limit)
         .map(|(score, m)| {
-            let _ = iii.trigger_void("state::update", json!({
+            let _ = {
+                let _iii = iii.clone();
+                let _payload = json!({
                 "scope": format!("memory:{}", m.agent_id),
                 "key": &m.id,
                 "operations": [
                     { "type": "increment", "path": "accessCount", "value": 1 },
                     { "type": "set", "path": "lastAccessed", "value": now_ms() },
                 ],
-            }));
+            });
+                tokio::spawn(async move {
+                    let _ = _iii.trigger(TriggerRequest {
+                        function_id: "state::update".to_string(),
+                        payload: _payload,
+                        action: None,
+                        timeout_ms: None,
+                    }).await;
+                });
+            };
 
             json!({
                 "role": m.role,
@@ -436,21 +369,31 @@ async fn kg_add(iii: &III, input: Value) -> Result<Value, IIIError> {
     let entity = &input["entity"];
     let entity_id = entity["id"].as_str().unwrap_or("");
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": format!("kg:{}", agent_id),
         "key": entity_id,
         "value": entity,
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     if let Some(relations) = entity["relations"].as_array() {
         for rel in relations {
             let target_id = rel["target"].as_str().unwrap_or("");
             let rel_type = rel["type"].as_str().unwrap_or("");
 
-            if let Ok(target) = iii.trigger_v0("state::get", json!({
+            if let Ok(target) = iii.trigger(TriggerRequest {
+                function_id: "state::get".to_string(),
+                payload: json!({
                 "scope": format!("kg:{}", agent_id),
                 "key": target_id,
-            })).await {
+            }),
+                action: None,
+                timeout_ms: None,
+            }).await {
                 let mut back_refs: Vec<Value> = target["relations"]
                     .as_array()
                     .cloned()
@@ -462,11 +405,16 @@ async fn kg_add(iii: &III, input: Value) -> Result<Value, IIIError> {
 
                 if !already {
                     back_refs.push(json!({ "target": entity_id, "type": format!("inverse:{}", rel_type) }));
-                    let _ = iii.trigger_v0("state::update", json!({
+                    let _ = iii.trigger(TriggerRequest {
+                        function_id: "state::update".to_string(),
+                        payload: json!({
                         "scope": format!("kg:{}", agent_id),
                         "key": target_id,
                         "operations": [{ "type": "set", "path": "relations", "value": back_refs }],
-                    })).await;
+                    }),
+                        action: None,
+                        timeout_ms: None,
+                    }).await;
                 }
             }
         }
@@ -490,10 +438,15 @@ async fn kg_query(iii: &III, input: Value) -> Result<Value, IIIError> {
         }
         visited.insert(id.clone());
 
-        if let Ok(entity) = iii.trigger_v0("state::get", json!({
+        if let Ok(entity) = iii.trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("kg:{}", agent_id),
             "key": &id,
-        })).await {
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await {
             if let Some(relations) = entity["relations"].as_array() {
                 for rel in relations {
                     if let Some(target) = rel["target"].as_str() {
@@ -514,7 +467,12 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
     let cap = input["cap"].as_u64().unwrap_or(10_000) as usize;
 
     let scopes: Value = iii
-        .trigger_v0("state::list_groups", json!({}))
+        .trigger(TriggerRequest {
+            function_id: "state::list_groups".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -532,7 +490,12 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     for scope in &memory_scopes {
         let entries: Value = iii
-            .trigger_v0("state::list", json!({ "scope": scope }))
+            .trigger(TriggerRequest {
+                function_id: "state::list".to_string(),
+                payload: json!({ "scope": scope }),
+                action: None,
+                timeout_ms: None,
+            })
             .await
             .unwrap_or(json!([]));
 
@@ -555,8 +518,18 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
             let is_low_confidence = m.confidence < 0.1;
 
             if (is_stale && is_low_value) || is_low_confidence {
-                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.id })).await;
-                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.hash })).await;
+                let _ = iii.trigger(TriggerRequest {
+                    function_id: "state::delete".to_string(),
+                    payload: json!({ "scope": scope, "key": &m.id }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
+                let _ = iii.trigger(TriggerRequest {
+                    function_id: "state::delete".to_string(),
+                    payload: json!({ "scope": scope, "key": &m.hash }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
                 scope_evicted += 1;
             }
         }
@@ -568,7 +541,12 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
 
             let overflow = (remaining - cap as u64) as usize;
             for m in sorted.into_iter().take(overflow) {
-                let _ = iii.trigger_v0("state::delete", json!({ "scope": scope, "key": &m.id })).await;
+                let _ = iii.trigger(TriggerRequest {
+                    function_id: "state::delete".to_string(),
+                    payload: json!({ "scope": scope, "key": &m.id }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
                 scope_evicted += 1;
             }
         }
@@ -584,7 +562,12 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
     let start = std::time::Instant::now();
 
     let scopes: Value = iii
-        .trigger_v0("state::list_groups", json!({}))
+        .trigger(TriggerRequest {
+            function_id: "state::list_groups".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -603,7 +586,12 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     for scope in &memory_scopes {
         let entries: Value = iii
-            .trigger_v0("state::list", json!({ "scope": scope }))
+            .trigger(TriggerRequest {
+                function_id: "state::list".to_string(),
+                payload: json!({ "scope": scope }),
+                action: None,
+                timeout_ms: None,
+            })
             .await
             .unwrap_or(json!([]));
 
@@ -622,13 +610,18 @@ async fn consolidate(iii: &III, input: Value) -> Result<Value, IIIError> {
 
             if now.saturating_sub(last_accessed) > seven_days_ms && confidence > 0.1 {
                 let new_confidence = (confidence * (1.0 - decay_rate)).max(0.1);
-                let _ = iii.trigger_v0("state::update", json!({
+                let _ = iii.trigger(TriggerRequest {
+                    function_id: "state::update".to_string(),
+                    payload: json!({
                     "scope": scope,
                     "key": id,
                     "operations": [
                         { "type": "set", "path": "confidence", "value": new_confidence },
                     ],
-                })).await;
+                }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
                 decayed += 1;
             }
         }
@@ -648,10 +641,15 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let keep_recent = input["keepRecent"].as_u64().unwrap_or(10) as usize;
 
     let session: Value = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!({}));
 
@@ -667,10 +665,15 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut full_messages = Vec::new();
     for msg_ref in to_summarize {
         let msg_id = msg_ref["id"].as_str().unwrap_or("");
-        if let Ok(entry) = iii.trigger_v0("state::get", json!({
+        if let Ok(entry) = iii.trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
-        })).await {
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await {
             full_messages.push(format!(
                 "{}: {}",
                 entry["role"].as_str().unwrap_or("unknown"),
@@ -684,11 +687,16 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut summaries = Vec::new();
 
     for chunk in &chunks {
-        let summary = iii.trigger_v0("llm::complete", json!({
+        let summary = iii.trigger(TriggerRequest {
+            function_id: "llm::complete".to_string(),
+            payload: json!({
             "model": { "provider": "anthropic", "model": "claude-haiku-4-5", "maxTokens": 1024 },
             "systemPrompt": "Summarize this conversation concisely. Preserve key facts, decisions, and context. Be brief.",
             "messages": [{ "role": "user", "content": chunk }],
-        })).await;
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await;
 
         if let Ok(resp) = summary {
             summaries.push(resp["content"].as_str().unwrap_or("").to_string());
@@ -700,7 +708,9 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let summary_id = uuid::Uuid::new_v4().to_string();
     let now = now_ms();
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": format!("memory:{}", agent_id),
         "key": &summary_id,
         "value": {
@@ -716,19 +726,27 @@ async fn compact_session(iii: &III, input: Value) -> Result<Value, IIIError> {
             "accessCount": 0_u64,
             "lastAccessed": now,
         },
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let mut new_messages = vec![json!({ "id": summary_id, "role": "system", "timestamp": now })];
     new_messages.extend(to_keep.iter().cloned());
 
-    iii.trigger_v0("state::update", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::update".to_string(),
+        payload: json!({
         "scope": format!("sessions:{}", agent_id),
         "key": session_id,
         "operations": [
             { "type": "set", "path": "messages", "value": new_messages },
             { "type": "set", "path": "compactedAt", "value": now },
         ],
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     Ok(json!({
         "compacted": true,
@@ -743,10 +761,15 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let session_id = input["sessionId"].as_str().unwrap_or("default");
 
     let session: Value = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!({}));
 
@@ -790,10 +813,15 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut orphaned = 0_u64;
     for msg in &repaired {
         let msg_id = msg["id"].as_str().unwrap_or("");
-        let exists = iii.trigger_v0("state::get", json!({
+        let exists = iii.trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
-        })).await;
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await;
         if exists.is_err() {
             orphaned += 1;
         }
@@ -817,10 +845,15 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
     let mut truncated = 0_u64;
     for msg in &repaired {
         let msg_id = msg["id"].as_str().unwrap_or("");
-        if let Ok(entry) = iii.trigger_v0("state::get", json!({
+        if let Ok(entry) = iii.trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": format!("memory:{}", agent_id),
             "key": msg_id,
-        })).await {
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await {
             let content_len = entry["content"].as_str().map(|s| s.len()).unwrap_or(0);
             if content_len > 500_000 {
                 truncated += 1;
@@ -831,7 +864,9 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     let total_repairs: u64 = stats.values().sum();
     if total_repairs > 0 {
-        iii.trigger_v0("state::update", json!({
+        iii.trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
             "scope": format!("sessions:{}", agent_id),
             "key": session_id,
             "operations": [
@@ -839,7 +874,10 @@ async fn repair_session(iii: &III, input: Value) -> Result<Value, IIIError> {
                 { "type": "set", "path": "repairedAt", "value": now_ms() },
                 { "type": "set", "path": "repairStats", "value": stats },
             ],
-        })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+        }),
+            action: None,
+            timeout_ms: None,
+        }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
     }
 
     Ok(json!({

--- a/workers/memory/src/main.rs
+++ b/workers/memory/src/main.rs
@@ -29,7 +29,8 @@ struct MemoryEntry {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_ref = iii.clone();
     iii.register_function(
@@ -544,6 +545,12 @@ async fn evict_memories(iii: &III, input: Value) -> Result<Value, IIIError> {
                 let _ = iii.trigger(TriggerRequest {
                     function_id: "state::delete".to_string(),
                     payload: json!({ "scope": scope, "key": &m.id }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
+                let _ = iii.trigger(TriggerRequest {
+                    function_id: "state::delete".to_string(),
+                    payload: json!({ "scope": scope, "key": &m.hash }),
                     action: None,
                     timeout_ms: None,
                 }).await;

--- a/workers/mission/src/main.rs
+++ b/workers/mission/src/main.rs
@@ -307,7 +307,8 @@ async fn list_missions(iii: &III, req: ListMissionsRequest) -> Result<Value, III
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/mission/src/main.rs
+++ b/workers/mission/src/main.rs
@@ -1,126 +1,7 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -164,28 +45,49 @@ async fn create_mission(iii: &III, req: CreateMissionRequest) -> Result<Value, I
 
     let value = serde_json::to_value(&mission).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": scope(&req.realm_id),
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "mission.lifecycle",
         "data": { "type": "created", "missionId": mission.id, "realmId": mission.realm_id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&mission).unwrap())
 }
 
 async fn load_mission(iii: &III, realm_id: &str, id: &str) -> Result<Mission, IIIError> {
     let val = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": scope(realm_id),
             "key": id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -194,11 +96,16 @@ async fn load_mission(iii: &III, realm_id: &str, id: &str) -> Result<Mission, II
 
 async fn save_mission(iii: &III, mission: &Mission) -> Result<(), IIIError> {
     let value = serde_json::to_value(mission).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": scope(&mission.realm_id),
         "key": mission.id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
     Ok(())
@@ -233,14 +140,25 @@ async fn checkout_mission(iii: &III, req: CheckoutRequest) -> Result<Value, IIIE
 
     save_mission(iii, &mission).await?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "mission.lifecycle",
         "data": {
             "type": "checked_out",
             "missionId": mission.id,
             "agentId": req.agent_id,
         },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&mission).unwrap())
 }
@@ -284,7 +202,9 @@ async fn transition_mission(iii: &III, req: TransitionRequest) -> Result<Value, 
 
     save_mission(iii, &mission).await?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "mission.lifecycle",
         "data": {
             "type": "transitioned",
@@ -294,7 +214,16 @@ async fn transition_mission(iii: &III, req: TransitionRequest) -> Result<Value, 
             "agentId": req.agent_id,
             "reason": req.reason,
         },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&mission).unwrap())
 }
@@ -313,11 +242,16 @@ async fn add_comment(iii: &III, req: CommentRequest) -> Result<Value, IIIError> 
 
     let value = serde_json::to_value(&comment).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": comments_scope(&realm_id, &req.mission_id),
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -325,16 +259,26 @@ async fn add_comment(iii: &III, req: CommentRequest) -> Result<Value, IIIError> 
 }
 
 async fn list_comments(iii: &III, realm_id: &str, mission_id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::list", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::list".to_string(),
+        payload: json!({
         "scope": comments_scope(realm_id, mission_id),
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
 async fn list_missions(iii: &III, req: ListMissionsRequest) -> Result<Value, IIIError> {
     let all = iii
-        .trigger_v0("state::list", json!({ "scope": scope(&req.realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope(&req.realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -366,38 +310,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::create",
-        "Create a new mission",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::create", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CreateMissionRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 create_mission(&iii, req).await
             }
-        },
+        })
+        .description("Create a new mission"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::checkout",
-        "Atomically claim a mission for an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::checkout", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CheckoutRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 checkout_mission(&iii, req).await
             }
-        },
+        })
+        .description("Atomically claim a mission for an agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::release",
-        "Release a mission back to the queue",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::release", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -411,56 +351,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing agentId".into()))?;
                 release_mission(&iii, realm_id, id, agent_id).await
             }
-        },
+        })
+        .description("Release a mission back to the queue"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::transition",
-        "Transition mission to a new status",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::transition", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: TransitionRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 transition_mission(&iii, req).await
             }
-        },
+        })
+        .description("Transition mission to a new status"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::list",
-        "List missions with filtering",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::list", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ListMissionsRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 list_missions(&iii, req).await
             }
-        },
+        })
+        .description("List missions with filtering"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::comment",
-        "Add a comment to a mission",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::comment", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CommentRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 add_comment(&iii, req).await
             }
-        },
+        })
+        .description("Add a comment to a mission"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "mission::comments",
-        "List comments on a mission",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("mission::comments", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -471,16 +407,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing missionId".into()))?;
                 list_comments(&iii, realm_id, mission_id).await
             }
-        },
+        })
+        .description("List comments on a mission"),
     );
 
-    iii.register_trigger_v0("http", "mission::create", json!({ "method": "POST", "path": "/api/missions" }))?;
-    iii.register_trigger_v0("http", "mission::checkout", json!({ "method": "POST", "path": "/api/missions/:id/checkout" }))?;
-    iii.register_trigger_v0("http", "mission::release", json!({ "method": "POST", "path": "/api/missions/:id/release" }))?;
-    iii.register_trigger_v0("http", "mission::transition", json!({ "method": "PATCH", "path": "/api/missions/:id/status" }))?;
-    iii.register_trigger_v0("http", "mission::list", json!({ "method": "GET", "path": "/api/missions/:realmId" }))?;
-    iii.register_trigger_v0("http", "mission::comment", json!({ "method": "POST", "path": "/api/missions/:id/comments" }))?;
-    iii.register_trigger_v0("http", "mission::comments", json!({ "method": "GET", "path": "/api/missions/:realmId/:missionId/comments" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::create".to_string(),
+        config: json!({ "method": "POST", "path": "/api/missions" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::checkout".to_string(),
+        config: json!({ "method": "POST", "path": "/api/missions/:id/checkout" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::release".to_string(),
+        config: json!({ "method": "POST", "path": "/api/missions/:id/release" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::transition".to_string(),
+        config: json!({ "method": "PATCH", "path": "/api/missions/:id/status" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::list".to_string(),
+        config: json!({ "method": "GET", "path": "/api/missions/:realmId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::comment".to_string(),
+        config: json!({ "method": "POST", "path": "/api/missions/:id/comments" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "mission::comments".to_string(),
+        config: json!({ "method": "GET", "path": "/api/missions/:realmId/:missionId/comments" }),
+        metadata: None,
+    })?;
 
     tracing::info!("mission worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/pulse/src/main.rs
+++ b/workers/pulse/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
@@ -6,125 +6,6 @@ mod types;
 
 use types::{ContextMode, InvokeRequest, PulseConfig, PulseRun, PulseStatus, RegisterPulseRequest};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -147,35 +28,55 @@ async fn build_context(iii: &III, agent_id: &str, realm_id: &str, mode: &Context
         }
         ContextMode::Full => {
             let missions = iii
-                .trigger_v0("mission::list", json!({
+                .trigger(TriggerRequest {
+                    function_id: "mission::list".to_string(),
+                    payload: json!({
                     "realmId": realm_id,
                     "assigneeId": agent_id,
                     "status": "active",
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await
                 .unwrap_or(json!({ "missions": [] }));
 
             let budget = iii
-                .trigger_v0("ledger::check", json!({
+                .trigger(TriggerRequest {
+                    function_id: "ledger::check".to_string(),
+                    payload: json!({
                     "realmId": realm_id,
                     "agentId": agent_id,
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await
                 .unwrap_or(json!({ "allowed": true }));
 
             let hierarchy = iii
-                .trigger_v0("hierarchy::chain", json!({
+                .trigger(TriggerRequest {
+                    function_id: "hierarchy::chain".to_string(),
+                    payload: json!({
                     "realmId": realm_id,
                     "agentId": agent_id,
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await
                 .unwrap_or(json!({ "chain": [] }));
 
             let directives = iii
-                .trigger_v0("directive::list", json!({
+                .trigger(TriggerRequest {
+                    function_id: "directive::list".to_string(),
+                    payload: json!({
                     "realmId": realm_id,
                     "status": "active",
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await
                 .unwrap_or(json!({ "directives": [] }));
 
@@ -205,23 +106,33 @@ async fn register_pulse(iii: &III, req: RegisterPulseRequest) -> Result<Value, I
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": config_scope(&req.realm_id),
         "key": &req.agent_id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let _ = iii
-        .trigger_v0("engine::triggers::register", json!({
+        .trigger(TriggerRequest {
+            function_id: "engine::triggers::register".to_string(),
+            payload: json!({
             "type": "cron",
             "function": "pulse::tick",
             "config": {
                 "schedule": req.cron,
                 "data": { "agentId": req.agent_id, "realmId": req.realm_id },
             },
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(format!("failed to register cron trigger: {e}")))?;
 
@@ -249,20 +160,30 @@ async fn invoke_pulse(iii: &III, req: InvokeRequest) -> Result<Value, IIIError> 
     };
 
     let run_val = serde_json::to_value(&run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": runs_scope(&realm_id),
         "key": &run_id,
         "value": run_val,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let result = iii
-        .trigger_v0("agent::chat", json!({
+        .trigger(TriggerRequest {
+            function_id: "agent::chat".to_string(),
+            payload: json!({
             "agentId": req.agent_id,
             "message": "You have been invoked via pulse. Review your current context and take appropriate action.",
             "context": context,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await;
 
     let (final_status, error) = match result {
@@ -278,11 +199,16 @@ async fn invoke_pulse(iii: &III, req: InvokeRequest) -> Result<Value, IIIError> 
     };
 
     let run_val = serde_json::to_value(&finished_run).map_err(|e| IIIError::Handler(e.to_string()))?;
-    let _ = iii.trigger_v0("state::set", json!({
+    let _ = iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": runs_scope(&realm_id),
         "key": &run_id,
         "value": run_val,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await;
 
     Ok(serde_json::to_value(&finished_run).unwrap())
@@ -297,10 +223,15 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
         .ok_or_else(|| IIIError::Handler("missing realmId in tick".into()))?;
 
     let config_val = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -312,10 +243,15 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let budget_check = iii
-        .trigger_v0("ledger::check", json!({
+        .trigger(TriggerRequest {
+            function_id: "ledger::check".to_string(),
+            payload: json!({
             "realmId": realm_id,
             "agentId": agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!({ "allowed": true }));
 
@@ -333,15 +269,25 @@ async fn tick(iii: &III, input: Value) -> Result<Value, IIIError> {
 
 async fn get_pulse_status(iii: &III, realm_id: &str, agent_id: &str) -> Result<Value, IIIError> {
     let config = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
     let runs = iii
-        .trigger_v0("state::list", json!({ "scope": runs_scope(realm_id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": runs_scope(realm_id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .ok();
 
@@ -364,10 +310,15 @@ async fn get_pulse_status(iii: &III, realm_id: &str, agent_id: &str) -> Result<V
 
 async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) -> Result<Value, IIIError> {
     let config_val = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": config_scope(realm_id),
             "key": agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -378,11 +329,16 @@ async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) 
 
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": config_scope(realm_id),
         "key": agent_id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
@@ -396,48 +352,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "pulse::register",
-        "Register scheduled pulse for an agent",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("pulse::register", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: RegisterPulseRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 register_pulse(&iii, req).await
             }
-        },
+        })
+        .description("Register scheduled pulse for an agent"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "pulse::invoke",
-        "Manually invoke agent pulse",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("pulse::invoke", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: InvokeRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 invoke_pulse(&iii, req).await
             }
-        },
+        })
+        .description("Manually invoke agent pulse"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "pulse::tick",
-        "Internal: cron-triggered pulse execution",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("pulse::tick", move |input: Value| {
             let iii = iii_clone.clone();
             async move { tick(&iii, input).await }
-        },
+        })
+        .description("Internal: cron-triggered pulse execution"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "pulse::status",
-        "Get pulse config and recent runs",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("pulse::status", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -448,14 +399,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing agentId".into()))?;
                 get_pulse_status(&iii, realm_id, agent_id).await
             }
-        },
+        })
+        .description("Get pulse config and recent runs"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "pulse::toggle",
-        "Enable or disable agent pulse",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("pulse::toggle", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let realm_id = input["realmId"]
@@ -467,13 +417,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let enabled = input["enabled"].as_bool().unwrap_or(true);
                 toggle_pulse(&iii, realm_id, agent_id, enabled).await
             }
-        },
+        })
+        .description("Enable or disable agent pulse"),
     );
 
-    iii.register_trigger_v0("http", "pulse::register", json!({ "method": "POST", "path": "/api/pulse/register" }))?;
-    iii.register_trigger_v0("http", "pulse::invoke", json!({ "method": "POST", "path": "/api/pulse/invoke" }))?;
-    iii.register_trigger_v0("http", "pulse::status", json!({ "method": "GET", "path": "/api/pulse/:realmId/:agentId" }))?;
-    iii.register_trigger_v0("http", "pulse::toggle", json!({ "method": "PATCH", "path": "/api/pulse/:realmId/:agentId" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "pulse::register".to_string(),
+        config: json!({ "method": "POST", "path": "/api/pulse/register" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "pulse::invoke".to_string(),
+        config: json!({ "method": "POST", "path": "/api/pulse/invoke" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "pulse::status".to_string(),
+        config: json!({ "method": "GET", "path": "/api/pulse/:realmId/:agentId" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "pulse::toggle".to_string(),
+        config: json!({ "method": "PATCH", "path": "/api/pulse/:realmId/:agentId" }),
+        metadata: None,
+    })?;
 
     tracing::info!("pulse worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/pulse/src/main.rs
+++ b/workers/pulse/src/main.rs
@@ -349,7 +349,8 @@ async fn toggle_pulse(iii: &III, realm_id: &str, agent_id: &str, enabled: bool) 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/realm/src/main.rs
+++ b/workers/realm/src/main.rs
@@ -279,7 +279,8 @@ async fn import_realm(iii: &III, req: ImportRequest) -> Result<Value, IIIError> 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
     iii.register_function(

--- a/workers/realm/src/main.rs
+++ b/workers/realm/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde_json::{json, Value};
 
@@ -6,125 +6,6 @@ mod types;
 
 use types::{CreateRealmRequest, ExportRequest, ImportRequest, Realm, RealmStatus, UpdateRealmRequest};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -147,33 +28,59 @@ async fn create_realm(iii: &III, req: CreateRealmRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&realm).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": "realms",
         "key": id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "realm.lifecycle",
         "data": { "type": "created", "realmId": realm.id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&realm).unwrap())
 }
 
 async fn get_realm(iii: &III, id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::get", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::get".to_string(),
+        payload: json!({
         "scope": "realms",
         "key": id,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
 async fn list_realms(iii: &III) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::list", json!({ "scope": "realms" }))
+    iii.trigger(TriggerRequest {
+        function_id: "state::list".to_string(),
+        payload: json!({ "scope": "realms" }),
+        action: None,
+        timeout_ms: None,
+    })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))
 }
@@ -205,34 +112,66 @@ async fn update_realm(iii: &III, req: UpdateRealmRequest) -> Result<Value, IIIEr
 
     let value = serde_json::to_value(&realm).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": "realms",
         "key": realm.id,
         "value": value,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "realm.lifecycle",
         "data": { "type": "updated", "realmId": realm.id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(serde_json::to_value(&realm).unwrap())
 }
 
 async fn delete_realm(iii: &III, id: &str) -> Result<Value, IIIError> {
-    iii.trigger_v0("state::delete", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::delete".to_string(),
+        payload: json!({
         "scope": "realms",
         "key": id,
-    }))
+    }),
+        action: None,
+        timeout_ms: None,
+    })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    let _ = iii.trigger_void("publish", json!({
+    let _ = {
+        let _iii = iii.clone();
+        let _payload = json!({
         "topic": "realm.lifecycle",
         "data": { "type": "deleted", "realmId": id },
-    }));
+    });
+        tokio::spawn(async move {
+            let _ = _iii.trigger(TriggerRequest {
+                function_id: "publish".to_string(),
+                payload: _payload,
+                action: None,
+                timeout_ms: None,
+            }).await;
+        });
+    };
 
     Ok(json!({ "deleted": true }))
 }
@@ -242,17 +181,32 @@ async fn export_realm(iii: &III, req: ExportRequest) -> Result<Value, IIIError> 
     let scrub = req.scrub_secrets.unwrap_or(true);
 
     let agents = iii
-        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:agents", req.id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": format!("realm:{}:agents", req.id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
     let directives = iii
-        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:directives", req.id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": format!("realm:{}:directives", req.id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
     let hierarchy = iii
-        .trigger_v0("state::list", json!({ "scope": format!("realm:{}:hierarchy", req.id) }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": format!("realm:{}:hierarchy", req.id) }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!([]));
 
@@ -301,11 +255,16 @@ async fn import_realm(iii: &III, req: ImportRequest) -> Result<Value, IIIError> 
             let mut agent = agent.clone();
             agent["realmId"] = json!(realm_id);
             let _ = iii
-                .trigger_v0("state::set", json!({
+                .trigger(TriggerRequest {
+                    function_id: "state::set".to_string(),
+                    payload: json!({
                     "scope": format!("realm:{realm_id}:agents"),
                     "key": agent["id"].as_str().unwrap_or("unknown"),
                     "value": agent,
-                }))
+                }),
+                    action: None,
+                    timeout_ms: None,
+                })
                 .await;
         }
     }
@@ -323,24 +282,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::create",
-        "Create a new isolated realm",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::create", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: CreateRealmRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 create_realm(&iii, req).await
             }
-        },
+        })
+        .description("Create a new isolated realm"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::get",
-        "Get realm by ID",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::get", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let id = input["id"]
@@ -348,38 +304,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing id".into()))?;
                 get_realm(&iii, id).await
             }
-        },
+        })
+        .description("Get realm by ID"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::list",
-        "List all realms",
-        move |_: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::list", move |_: Value| {
             let iii = iii_clone.clone();
             async move { list_realms(&iii).await }
-        },
+        })
+        .description("List all realms"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::update",
-        "Update realm configuration",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::update", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: UpdateRealmRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 update_realm(&iii, req).await
             }
-        },
+        })
+        .description("Update realm configuration"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::delete",
-        "Delete a realm and all its data",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::delete", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let id = input["id"]
@@ -387,44 +340,78 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .ok_or_else(|| IIIError::Handler("missing id".into()))?;
                 delete_realm(&iii, id).await
             }
-        },
+        })
+        .description("Delete a realm and all its data"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::export",
-        "Export realm as portable template",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::export", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ExportRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 export_realm(&iii, req).await
             }
-        },
+        })
+        .description("Export realm as portable template"),
     );
 
     let iii_clone = iii.clone();
-    iii.register_function_with_description(
-        "realm::import",
-        "Import realm from template",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("realm::import", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
                 let req: ImportRequest =
                     serde_json::from_value(input).map_err(|e| IIIError::Handler(e.to_string()))?;
                 import_realm(&iii, req).await
             }
-        },
+        })
+        .description("Import realm from template"),
     );
 
-    iii.register_trigger_v0("http", "realm::create", json!({ "method": "POST", "path": "/api/realms" }))?;
-    iii.register_trigger_v0("http", "realm::list", json!({ "method": "GET", "path": "/api/realms" }))?;
-    iii.register_trigger_v0("http", "realm::get", json!({ "method": "GET", "path": "/api/realms/:id" }))?;
-    iii.register_trigger_v0("http", "realm::update", json!({ "method": "PATCH", "path": "/api/realms/:id" }))?;
-    iii.register_trigger_v0("http", "realm::delete", json!({ "method": "DELETE", "path": "/api/realms/:id" }))?;
-    iii.register_trigger_v0("http", "realm::export", json!({ "method": "POST", "path": "/api/realms/:id/export" }))?;
-    iii.register_trigger_v0("http", "realm::import", json!({ "method": "POST", "path": "/api/realms/import" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::create".to_string(),
+        config: json!({ "method": "POST", "path": "/api/realms" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::list".to_string(),
+        config: json!({ "method": "GET", "path": "/api/realms" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::get".to_string(),
+        config: json!({ "method": "GET", "path": "/api/realms/:id" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::update".to_string(),
+        config: json!({ "method": "PATCH", "path": "/api/realms/:id" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::delete".to_string(),
+        config: json!({ "method": "DELETE", "path": "/api/realms/:id" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::export".to_string(),
+        config: json!({ "method": "POST", "path": "/api/realms/:id/export" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "realm::import".to_string(),
+        config: json!({ "method": "POST", "path": "/api/realms/import" }),
+        metadata: None,
+    })?;
 
     tracing::info!("realm worker started");
     tokio::signal::ctrl_c().await?;

--- a/workers/security/src/docker_sandbox.rs
+++ b/workers/security/src/docker_sandbox.rs
@@ -1,128 +1,9 @@
-use iii_sdk::iii::III;
+use iii_sdk::{III, RegisterFunction};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::process::Stdio;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -927,10 +808,9 @@ mod tests {
 }
 
 pub fn register(iii: &III) {
-    iii.register_function_with_description(
-        "security::docker_exec",
-        "Execute a command inside a Docker container sandbox",
-        move |input: Value| async move { docker_exec(input).await },
+    iii.register_function(
+        RegisterFunction::new_async("security::docker_exec", move |input: Value| async move { docker_exec(input).await })
+        .description("Execute a command inside a Docker container sandbox"),
     );
 }
 

--- a/workers/security/src/main.rs
+++ b/workers/security/src/main.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
@@ -6,125 +6,6 @@ use serde_json::{json, Value};
 use sha2::Sha256;
 use std::sync::OnceLock;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -187,84 +68,110 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let iii = register_worker("ws://localhost:49134", InitOptions::default());
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "security::check_capability",
-        "RBAC capability enforcement",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("security::check_capability", move |input: Value| {
             let iii = iii_ref.clone();
             async move { check_capability(&iii, input).await }
-        },
+        })
+        .description("RBAC capability enforcement"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "security::set_capabilities",
-        "Set agent capabilities",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("security::set_capabilities", move |input: Value| {
             let iii = iii_ref.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("");
                 let caps = &input["capabilities"];
 
-                iii.trigger_v0("state::set", json!({
+                iii.trigger(TriggerRequest {
+                    function_id: "state::set".to_string(),
+                    payload: json!({
                     "scope": "capabilities",
                     "key": agent_id,
                     "value": caps,
-                })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+                }),
+                    action: None,
+                    timeout_ms: None,
+                }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                iii.trigger_void("security::audit", json!({
+                {
+                    let _iii = iii.clone();
+                    let _payload = json!({
                     "type": "capabilities_updated",
                     "agentId": agent_id,
                     "detail": { "tools": caps["tools"].as_array().map(|a| a.len()).unwrap_or(0) },
-                }))?;
+                });
+                    tokio::spawn(async move {
+                        let _ = _iii.trigger(TriggerRequest {
+                            function_id: "security::audit".to_string(),
+                            payload: _payload,
+                            action: None,
+                            timeout_ms: None,
+                        }).await;
+                    });
+                };
 
-                Ok(json!({ "updated": true }))
+                Ok::<Value, IIIError>(json!({ "updated": true }))
             }
-        },
+        })
+        .description("Set agent capabilities"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "security::audit",
-        "Append to merkle audit chain",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("security::audit", move |input: Value| {
             let iii = iii_ref.clone();
             async move { append_audit(&iii, input).await }
-        },
+        })
+        .description("Append to merkle audit chain"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "security::verify_audit",
-        "Verify audit chain integrity",
-        move |_: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("security::verify_audit", move |_: Value| {
             let iii = iii_ref.clone();
             async move { verify_audit(&iii).await }
-        },
+        })
+        .description("Verify audit chain integrity"),
     );
 
-    iii.register_function_with_description(
-        "security::scan_injection",
-        "Scan text for prompt injection patterns",
-        move |input: Value| async move {
+    iii.register_function(
+        RegisterFunction::new_async("security::scan_injection", move |input: Value| async move {
             let text = input["text"].as_str().unwrap_or("");
             scan_injection(text)
-        },
+        })
+        .description("Scan text for prompt injection patterns"),
     );
 
-    iii.register_trigger_v0("subscribe", "security::audit", json!({
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "subscribe".to_string(),
+        function_id: "security::audit".to_string(),
+        config: json!({
         "topic": "audit",
-    }))?;
+    }),
+        metadata: None,
+    })?;
 
-    iii.register_trigger_v0("http", "security::verify_audit", json!({
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "security::verify_audit".to_string(),
+        config: json!({
         "api_path": "security/audit/verify",
         "http_method": "GET",
-    }))?;
+    }),
+        metadata: None,
+    })?;
 
-    iii.register_trigger_v0("http", "security::scan_injection", json!({
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "security::scan_injection".to_string(),
+        config: json!({
         "api_path": "security/scan",
         "http_method": "POST",
-    }))?;
+    }),
+        metadata: None,
+    })?;
 
     taint::register(&iii);
     signing::register(&iii);
@@ -289,10 +196,15 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let caps: Value = iii
-        .trigger_v0("state::get", json!({
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({
             "scope": "capabilities",
             "key": agent_id,
-        }))
+        }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|_| IIIError::Handler(format!("Agent {} has no capabilities defined", agent_id)))?;
 
@@ -304,28 +216,55 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
     let allowed = tools.iter().any(|t| *t == "*" || resource.starts_with(t));
 
     if !allowed {
-        iii.trigger_void("security::audit", json!({
+        {
+            let _iii = iii.clone();
+            let _payload = json!({
             "type": "capability_denied",
             "agentId": agent_id,
             "detail": { "resource": resource, "reason": "tool_not_allowed" },
-        }))?;
+        });
+            tokio::spawn(async move {
+                let _ = _iii.trigger(TriggerRequest {
+                    function_id: "security::audit".to_string(),
+                    payload: _payload,
+                    action: None,
+                    timeout_ms: None,
+                }).await;
+            });
+        };
         return Err(IIIError::Handler(format!("Agent {} denied: {}", agent_id, resource)));
     }
 
     let max_tokens = caps["max_tokens_per_hour"].as_u64().unwrap_or(0);
     if max_tokens > 0 {
         let usage: Value = iii
-            .trigger_v0("state::get", json!({ "scope": "metering", "key": agent_id }))
+            .trigger(TriggerRequest {
+                function_id: "state::get".to_string(),
+                payload: json!({ "scope": "metering", "key": agent_id }),
+                action: None,
+                timeout_ms: None,
+            })
             .await
             .unwrap_or(json!({}));
 
         let used = usage["totalTokens"].as_u64().unwrap_or(0);
         if used > max_tokens {
-            iii.trigger_void("security::audit", json!({
+            {
+                let _iii = iii.clone();
+                let _payload = json!({
                 "type": "quota_exceeded",
                 "agentId": agent_id,
                 "detail": { "used": used, "limit": max_tokens },
-            }))?;
+            });
+                tokio::spawn(async move {
+                    let _ = _iii.trigger(TriggerRequest {
+                        function_id: "security::audit".to_string(),
+                        payload: _payload,
+                        action: None,
+                        timeout_ms: None,
+                    }).await;
+                });
+            };
             return Err(IIIError::Handler(format!("Agent {} exceeded token quota", agent_id)));
         }
     }
@@ -335,7 +274,12 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
 
 async fn append_audit(iii: &III, input: Value) -> Result<Value, IIIError> {
     let prev: Value = iii
-        .trigger_v0("state::get", json!({ "scope": "audit", "key": "__latest" }))
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": "audit", "key": "__latest" }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .unwrap_or(json!({ "hash": "0".repeat(64) }));
 
@@ -371,24 +315,39 @@ async fn append_audit(iii: &III, input: Value) -> Result<Value, IIIError> {
         "prevHash": &prev_hash,
     });
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": "audit",
         "key": &id,
         "value": &full_entry,
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    iii.trigger_v0("state::set", json!({
+    iii.trigger(TriggerRequest {
+        function_id: "state::set".to_string(),
+        payload: json!({
         "scope": "audit",
         "key": "__latest",
         "value": { "hash": &hash, "id": &id, "timestamp": timestamp },
-    })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+    }),
+        action: None,
+        timeout_ms: None,
+    }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
     Ok(json!({ "id": id, "hash": hash }))
 }
 
 async fn verify_audit(iii: &III) -> Result<Value, IIIError> {
     let entries: Value = iii
-        .trigger_v0("state::list", json!({ "scope": "audit" }))
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": "audit" }),
+            action: None,
+            timeout_ms: None,
+        })
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
 

--- a/workers/security/src/main.rs
+++ b/workers/security/src/main.rs
@@ -65,7 +65,8 @@ static INJECTION_PATTERNS: &[&str] = &[
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_ref = iii.clone();
     iii.register_function(

--- a/workers/security/src/signing.rs
+++ b/workers/security/src/signing.rs
@@ -1,128 +1,9 @@
-use iii_sdk::iii::III;
+use iii_sdk::{III, RegisterFunction};
 use iii_sdk::error::IIIError;
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -199,10 +80,8 @@ fn verify_manifest(manifest: &Value, signature_hex: &str, public_key_hex: &str) 
 }
 
 pub fn register(iii: &III) {
-    iii.register_function_with_description(
-        "security::sign_manifest",
-        "Sign a manifest with Ed25519",
-        move |input: Value| async move {
+    iii.register_function(
+        RegisterFunction::new_async("security::sign_manifest", move |input: Value| async move {
             let manifest = input.get("manifest").cloned().unwrap_or(json!({}));
             let private_key = input["privateKey"]
                 .as_str()
@@ -211,17 +90,16 @@ pub fn register(iii: &III) {
             let signature = sign_manifest(&manifest, private_key)?;
             let digest = hex::encode(hash_manifest(&manifest));
 
-            Ok(json!({
+            Ok::<Value, IIIError>(json!({
                 "signature": signature,
                 "digest": digest,
             }))
-        },
+        })
+        .description("Sign a manifest with Ed25519"),
     );
 
-    iii.register_function_with_description(
-        "security::verify_manifest",
-        "Verify a manifest signature with Ed25519",
-        move |input: Value| async move {
+    iii.register_function(
+        RegisterFunction::new_async("security::verify_manifest", move |input: Value| async move {
             let manifest = input.get("manifest").cloned().unwrap_or(json!({}));
             let signature = input["signature"]
                 .as_str()
@@ -233,11 +111,12 @@ pub fn register(iii: &III) {
             let valid = verify_manifest(&manifest, signature, public_key)?;
             let digest = hex::encode(hash_manifest(&manifest));
 
-            Ok(json!({
+            Ok::<Value, IIIError>(json!({
                 "valid": valid,
                 "digest": digest,
             }))
-        },
+        })
+        .description("Verify a manifest signature with Ed25519"),
     );
 }
 

--- a/workers/security/src/taint.rs
+++ b/workers/security/src/taint.rs
@@ -1,128 +1,9 @@
-use iii_sdk::iii::III;
+use iii_sdk::{III, RegisterFunction, TriggerRequest};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -713,10 +594,8 @@ mod tests {
 
 pub fn register(iii: &III) {
     let _iii_declassify = iii.clone();
-    iii.register_function_with_description(
-        "taint::label",
-        "Apply taint labels to a value",
-        move |input: Value| async move {
+    iii.register_function(
+        RegisterFunction::new_async("taint::label", move |input: Value| async move {
             let value = input.get("value").cloned().unwrap_or(json!(null));
             let label_strs = input["labels"]
                 .as_array()
@@ -730,13 +609,12 @@ pub fn register(iii: &III) {
 
             let tainted = TaintedValue::new(value, TaintSet::from_labels(labels));
             serde_json::to_value(tainted).map_err(|e| IIIError::Handler(e.to_string()))
-        },
+        })
+        .description("Apply taint labels to a value"),
     );
 
-    iii.register_function_with_description(
-        "taint::check",
-        "Check if tainted value can flow to a sink",
-        move |input: Value| async move {
+    iii.register_function(
+        RegisterFunction::new_async("taint::check", move |input: Value| async move {
             let taint_set: TaintSet = serde_json::from_value(
                 input.get("taints").cloned().unwrap_or(json!({ "labels": [] }))
             ).map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -752,19 +630,18 @@ pub fn register(iii: &III) {
                 vec![]
             };
 
-            Ok(json!({
+            Ok::<Value, IIIError>(json!({
                 "allowed": allowed,
                 "sink": sink_str,
                 "blockingLabels": blocking_labels,
             }))
-        },
+        })
+        .description("Check if tainted value can flow to a sink"),
     );
 
     let iii_for_declassify = _iii_declassify;
-    iii.register_function_with_description(
-        "taint::declassify",
-        "Remove taint labels from a value",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("taint::declassify", move |input: Value| {
             let iii = iii_for_declassify.clone();
             async move {
                 let mut taint_set: TaintSet = serde_json::from_value(
@@ -782,15 +659,27 @@ pub fn register(iii: &III) {
                     }
                 }
 
-                let _ = iii.trigger_void("security::audit", json!({
+                let _ = {
+                    let _iii = iii.clone();
+                    let _payload = json!({
                     "type": "taint_declassified",
                     "detail": { "removedLabels": &remove_strs },
-                }));
+                });
+                    tokio::spawn(async move {
+                        let _ = _iii.trigger(TriggerRequest {
+                            function_id: "security::audit".to_string(),
+                            payload: _payload,
+                            action: None,
+                            timeout_ms: None,
+                        }).await;
+                    });
+                };
 
                 let value = input.get("value").cloned().unwrap_or(json!(null));
                 let result = TaintedValue::new(value, taint_set);
                 serde_json::to_value(result).map_err(|e| IIIError::Handler(e.to_string()))
             }
-        },
+        })
+        .description("Remove taint labels from a value"),
     );
 }

--- a/workers/security/src/tool_policy.rs
+++ b/workers/security/src/tool_policy.rs
@@ -1,127 +1,8 @@
-use iii_sdk::iii::III;
+use iii_sdk::{III, RegisterFunction, TriggerRequest};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -736,10 +617,8 @@ mod tests {
 
 pub fn register(iii: &III) {
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "policy::check",
-        "Check if a tool invocation is allowed by policy",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("policy::check", move |input: Value| {
             let iii = iii_ref.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("");
@@ -748,19 +627,29 @@ pub fn register(iii: &III) {
                 let current_concurrency = input["currentConcurrency"].as_u64().unwrap_or(0) as u32;
 
                 let agent_policy: Option<PolicyConfig> = iii
-                    .trigger_v0("state::get", json!({
+                    .trigger(TriggerRequest {
+                        function_id: "state::get".to_string(),
+                        payload: json!({
                         "scope": "policies",
                         "key": agent_id,
-                    }))
+                    }),
+                        action: None,
+                        timeout_ms: None,
+                    })
                     .await
                     .ok()
                     .and_then(|v| serde_json::from_value(v).ok());
 
                 let global_policy: Option<PolicyConfig> = iii
-                    .trigger_v0("state::get", json!({
+                    .trigger(TriggerRequest {
+                        function_id: "state::get".to_string(),
+                        payload: json!({
                         "scope": "policies",
                         "key": "__global",
-                    }))
+                    }),
+                        action: None,
+                        timeout_ms: None,
+                    })
                     .await
                     .ok()
                     .and_then(|v| serde_json::from_value(v).ok());
@@ -805,21 +694,20 @@ pub fn register(iii: &III) {
 
                 let allowed = action == PolicyAction::Allow;
 
-                Ok(json!({
+                Ok::<Value, IIIError>(json!({
                     "allowed": allowed,
                     "action": action,
                     "tool": tool_name,
                     "agentId": agent_id,
                 }))
             }
-        },
+        })
+        .description("Check if a tool invocation is allowed by policy"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "policy::set_rules",
-        "Set policy rules for an agent or globally",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("policy::set_rules", move |input: Value| {
             let iii = iii_ref.clone();
             async move {
                 let key = input["agentId"]
@@ -831,28 +719,43 @@ pub fn register(iii: &III) {
                     input.get("policy").cloned().unwrap_or(json!({ "rules": [] }))
                 ).map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                iii.trigger_v0("state::set", json!({
+                iii.trigger(TriggerRequest {
+                    function_id: "state::set".to_string(),
+                    payload: json!({
                     "scope": "policies",
                     "key": &key,
                     "value": &policy,
-                })).await.map_err(|e| IIIError::Handler(e.to_string()))?;
+                }),
+                    action: None,
+                    timeout_ms: None,
+                }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                iii.trigger_void("security::audit", json!({
+                {
+                    let _iii = iii.clone();
+                    let _payload = json!({
                     "type": "policy_updated",
                     "agentId": &key,
                     "detail": { "ruleCount": policy.rules.len() },
-                }))?;
+                });
+                    tokio::spawn(async move {
+                        let _ = _iii.trigger(TriggerRequest {
+                            function_id: "security::audit".to_string(),
+                            payload: _payload,
+                            action: None,
+                            timeout_ms: None,
+                        }).await;
+                    });
+                };
 
-                Ok(json!({ "updated": true, "key": key, "ruleCount": policy.rules.len() }))
+                Ok::<Value, IIIError>(json!({ "updated": true, "key": key, "ruleCount": policy.rules.len() }))
             }
-        },
+        })
+        .description("Set policy rules for an agent or globally"),
     );
 
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "policy::get_rules",
-        "Get policy rules for an agent or globally",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("policy::get_rules", move |input: Value| {
             let iii = iii_ref.clone();
             async move {
                 let key = input["agentId"]
@@ -860,18 +763,24 @@ pub fn register(iii: &III) {
                     .unwrap_or("__global");
 
                 let policy: Value = iii
-                    .trigger_v0("state::get", json!({
+                    .trigger(TriggerRequest {
+                        function_id: "state::get".to_string(),
+                        payload: json!({
                         "scope": "policies",
                         "key": key,
-                    }))
+                    }),
+                        action: None,
+                        timeout_ms: None,
+                    })
                     .await
                     .unwrap_or(json!({ "rules": [], "maxSubagentDepth": 5, "maxConcurrency": 10 }));
 
-                Ok(json!({
+                Ok::<Value, IIIError>(json!({
                     "key": key,
                     "policy": policy,
                 }))
             }
-        },
+        })
+        .description("Get policy rules for an agent or globally"),
     );
 }

--- a/workers/wasm-sandbox/src/main.rs
+++ b/workers/wasm-sandbox/src/main.rs
@@ -117,7 +117,8 @@ fn unpack_ptr_len(packed: i64) -> (u32, u32) {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let iii = register_worker(&ws_url, InitOptions::default());
 
     let mut config = Config::new();
     config.consume_fuel(true);

--- a/workers/wasm-sandbox/src/main.rs
+++ b/workers/wasm-sandbox/src/main.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use iii_sdk::{III, InitOptions, register_worker};
+use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use iii_sdk::error::IIIError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -7,125 +7,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use wasmtime::*;
 
-#[allow(dead_code)]
-mod iii_compat {
-    use iii_sdk::{
-        III, RegisterFunction, RegisterTriggerInput, TriggerRequest, FunctionRef, Trigger,
-        Value,
-    };
-    use iii_sdk::error::IIIError;
-    use std::future::Future;
-
-    pub trait IIIExt {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static;
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError>;
-
-        fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> impl Future<Output = Result<Value, IIIError>> + Send;
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError>;
-    }
-
-    impl IIIExt for III {
-        fn register_function_with_description<F, Fut>(
-            &self,
-            id: &str,
-            desc: &str,
-            f: F,
-        ) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(
-                RegisterFunction::new_async(id.to_string(), f).description(desc.to_string()),
-            )
-        }
-
-        fn register_function_v0<F, Fut>(&self, id: &str, f: F) -> FunctionRef
-        where
-            F: Fn(Value) -> Fut + Send + Sync + 'static,
-            Fut: Future<Output = Result<Value, IIIError>> + Send + 'static,
-        {
-            self.register_function(RegisterFunction::new_async(id.to_string(), f))
-        }
-
-        fn register_trigger_v0(
-            &self,
-            kind: &str,
-            function_id: &str,
-            config: Value,
-        ) -> Result<Trigger, IIIError> {
-            self.register_trigger(RegisterTriggerInput {
-                trigger_type: kind.to_string(),
-                function_id: function_id.to_string(),
-                config,
-                metadata: None,
-            })
-        }
-
-        async fn trigger_v0(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<Value, IIIError> {
-            self.trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        }
-
-        fn trigger_void(
-            &self,
-            function_id: &str,
-            payload: Value,
-        ) -> Result<(), IIIError> {
-            let iii = self.clone();
-            let fid = function_id.to_string();
-            tokio::spawn(async move {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: fid,
-                        payload,
-                        action: None,
-                        timeout_ms: None,
-                    })
-                    .await;
-            });
-            Ok(())
-        }
-    }
-}
-use iii_compat::IIIExt as _;
 
 
 
@@ -258,42 +139,54 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cache_ref = cache.clone();
     let iii_ref = iii.clone();
-    iii.register_function_with_description(
-        "wasm::execute",
-        "Execute WASM module in sandboxed environment",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("wasm::execute", move |input: Value| {
             let cache = cache_ref.clone();
             let iii = iii_ref.clone();
             async move { execute_wasm(&iii, &cache, input).await }
-        },
+        })
+        .description("Execute WASM module in sandboxed environment"),
     );
 
     let cache_ref = cache.clone();
-    iii.register_function_with_description(
-        "wasm::validate",
-        "Validate and cache a WASM module",
-        move |input: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("wasm::validate", move |input: Value| {
             let cache = cache_ref.clone();
             async move { validate_wasm(&cache, input).await }
-        },
+        })
+        .description("Validate and cache a WASM module"),
     );
 
     let cache_ref = cache.clone();
-    iii.register_function_with_description(
-        "wasm::list_modules",
-        "List cached WASM modules",
-        move |_: Value| {
+    iii.register_function(
+        RegisterFunction::new_async("wasm::list_modules", move |_: Value| {
             let cache = cache_ref.clone();
             async move {
                 let ids: Vec<String> = cache.modules.iter().map(|e| e.key().clone()).collect();
-                Ok(json!({ "modules": ids, "count": ids.len() }))
+                Ok::<Value, IIIError>(json!({ "modules": ids, "count": ids.len() }))
             }
-        },
+        })
+        .description("List cached WASM modules"),
     );
 
-    iii.register_trigger_v0("http", "wasm::execute", json!({ "api_path": "wasm/execute", "http_method": "POST" }))?;
-    iii.register_trigger_v0("http", "wasm::validate", json!({ "api_path": "wasm/validate", "http_method": "POST" }))?;
-    iii.register_trigger_v0("http", "wasm::list_modules", json!({ "api_path": "wasm/modules", "http_method": "GET" }))?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "wasm::execute".to_string(),
+        config: json!({ "api_path": "wasm/execute", "http_method": "POST" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "wasm::validate".to_string(),
+        config: json!({ "api_path": "wasm/validate", "http_method": "POST" }),
+        metadata: None,
+    })?;
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "http".to_string(),
+        function_id: "wasm::list_modules".to_string(),
+        config: json!({ "api_path": "wasm/modules", "http_method": "GET" }),
+        metadata: None,
+    })?;
 
     tracing::info!("wasm-sandbox worker started");
     tokio::signal::ctrl_c().await?;
@@ -402,17 +295,27 @@ async fn execute_wasm(iii: &III, cache: &ModuleCache, input: Value) -> Result<Va
                 .build()
                 .unwrap();
             rt.block_on(async {
-                let cap_check = iii_inner.trigger_v0("security::check_capability", json!({
+                let cap_check = iii_inner.trigger(TriggerRequest {
+                    function_id: "security::check_capability".to_string(),
+                    payload: json!({
                     "agentId": &agent,
                     "capability": func_id.split("::").next().unwrap_or(""),
                     "resource": &func_id,
-                })).await;
+                }),
+                    action: None,
+                    timeout_ms: None,
+                }).await;
 
                 if cap_check.is_err() {
                     return json!({ "error": "capability denied" }).to_string();
                 }
 
-                match iii_inner.trigger_v0(&func_id, args).await {
+                match iii_inner.trigger(TriggerRequest {
+                    function_id: func_id.to_string(),
+                    payload: args,
+                    action: None,
+                    timeout_ms: None,
+                }).await {
                     Ok(v) => v.to_string(),
                     Err(e) => json!({ "error": e.to_string() }).to_string(),
                 }


### PR DESCRIPTION
Final shim removal. Migrates 12 Rust workers + 4 security submodules off the per-worker \`mod iii_compat { ... }\` extension trait introduced in #35 as migration scaffolding. Same pattern as #36 (llm-router), now applied across the workspace.

## Scope

agent-core, bridge, council, directive, hierarchy, ledger, memory, mission, pulse, realm, security (+ submodules: signing, docker_sandbox, taint, tool_policy), wasm-sandbox.

llm-router was already done in #36. After this PR, the iii_compat module is gone from the repo.

## Transformations

| 0.8-shim | 0.11.4 native |
|---|---|
| \`iii.register_function_with_description(id, desc, h)\` | \`iii.register_function(RegisterFunction::new_async(id, h).description(desc))\` |
| \`iii.register_function_v0(id, h)\` | \`iii.register_function(RegisterFunction::new_async(id, h))\` |
| \`iii.register_trigger_v0(\"kind\", id, cfg)?\` | \`iii.register_trigger(RegisterTriggerInput { trigger_type, function_id, config, metadata: None })?\` |
| \`iii.trigger_v0(name, payload).await?\` | \`iii.trigger(TriggerRequest { function_id, payload, action: None, timeout_ms: None }).await?\` |
| \`iii.trigger_void(name, payload)?\` | inline \`tokio::spawn\` with same TriggerRequest, result discarded |

## Type-inference annotations

Six handlers had \`move |input| async move { ... Ok(json!(...)) }\` with no \`?\`. The compat shim's typed signature pinned \`E = IIIError\`; the native API needs explicit \`Ok::<Value, IIIError>(...)\` on the tail to close inference. Annotated those.

## LOC

16 files changed, **+1,793 / -2,632** (-839 net). Savings come from dropping the 13 \`iii_compat\` blocks (~140 LOC each). Handler bodies are otherwise byte-identical.

## Verification

\`\`\`
cargo check --workspace          # clean
cargo test  --workspace          # 831 passed, 0 failed (was 827 + 4 new from llm-router #36)
\`\`\`

CI from #35 covers \`cargo build --release\`, e2e smoke (workers register function counts, namespace clash check), and e2e full when secrets available.

## Status of the agent OS goal

| layer | state |
|---|---|
| Rust + Python workers in \`workers/\` | ✅ 14 |
| iii-sdk 0.11.4-next.4 native builder API | ✅ all workers, no shim |
| \`iii.worker.yaml\` per worker | ✅ canonical shape |
| \`wasm::*\` namespace, no clash with builtin \`sandbox::*\` | ✅ |
| CI: cargo build/test, e2e smoke, namespace check | ✅ |
| \`dependencies:\` blocks per worker | ⏳ blocked on registry publishing |
| Atomic append in \`council\` | ⏳ separate PR |
| \`bridge\` → \`iii-shell-client\` | ⏳ blocked on crate publishing |
| \`iii.lock\` pinning | ⏳ blocked on registry presence |
| \`hands/\`, \`integrations/\`, \`agents/\` as workers | ⏳ next phase (further decomposition) |

This closes the structural piece. Remaining work is registry publication + declarative wiring + further decomposition of \`hands/\` / \`integrations/\` into workers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all workers to use the modern SDK for function registration and trigger invocation, removing legacy compatibility wrappers for more consistent behavior.
* **Chores**
  * Worker websocket endpoint is now configurable via an environment variable (retains previous localhost default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->