### PR TITLE
ci: vercel deploy-hook workflow (auto-deploy is stuck)

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,25 @@
+name: vercel deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/vercel-deploy.yml'
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    name: trigger vercel production deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger via deploy hook
+        env:
+          HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "${HOOK_URL:-}" ]; then
+            echo "::warning::VERCEL_DEPLOY_HOOK_URL not set; create one in Vercel project Settings -> Git -> Deploy Hooks (branch=main) and add as repo secret"
+            exit 0
+          fi
+          response=$(curl -fsSL -X POST "$HOOK_URL")
+          echo "vercel response: $response"


### PR DESCRIPTION
Vercel project shows main as production branch but last deploy is c664876 from Apr 3 (the canvas merge). #36, #37, #38 plus an empty trigger commit on main since then = zero new production deploys. Live site at https://agentsos.sh still serves the canvas.

Webhook is broken or auto-deploy disabled in Settings → Git.

## Fix

GitHub Actions workflow that calls a Vercel Deploy Hook on push to main when website/** changes.

## Setup (one-time, in Vercel UI)

1. Project Settings → Git → Deploy Hooks → Create Hook
2. Name: \`main\`, Branch: \`main\`
3. Copy the URL (\`https://api.vercel.com/v1/integrations/deploy/<id>/<hash>\`)
4. GitHub repo Settings → Secrets and variables → Actions → add \`VERCEL_DEPLOY_HOOK_URL\` with that URL

After that, every push to main touching \`website/**\` triggers a production deploy. Manual re-trigger via Actions UI → "vercel deploy" → "Run workflow".

## Investigation followup

Root cause of why the existing integration stopped firing should still be checked — paused auto-deploy, broken webhook signature, or an "Ignored Build Step" command set to skip. Deploy hook is independent so works regardless.

After this lands and the secret is set, push any website change (or trigger workflow manually) to ship the revert + the 6 follow-up fixes from #37 to production.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated production deployment workflow that triggers when changes are pushed to the main branch, with support for manual deployment runs via GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->