### PR TITLE
fix(embedding): add iii.worker.yaml + bump iii-sdk to 0.11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,11 @@ jobs:
         run: chmod +x target/release/agentos-*
 
       - name: install iii CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
-            curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
+          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
           echo "$HOME/.iii/bin" >> $GITHUB_PATH
 
       - name: verify iii version
@@ -229,9 +230,11 @@ jobs:
         run: chmod +x target/release/agentos-*
 
       - name: install iii CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --version 0.11.4-next.4 || \
-            curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
+          set -e
+          curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
           echo "$HOME/.iii/bin" >> $GITHUB_PATH
 
       - name: skip if no api key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
           fail = False
           for d in sorted(Path("workers").iterdir()):
-              if not d.is_dir() or d.name == "embedding":
+              if not d.is_dir():
                   continue
               p = d / "iii.worker.yaml"
               if not p.exists():

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# AgentOS architecture
+
+AgentOS is an agent operating system built on the [iii engine](https://github.com/iii-hq/iii).
+The repo ships **narrow workers** (one binary per domain), declarative
+configuration (hands, integrations, agents), and surfaces (`cli`, `tui`).
+Everything coordinates through iii primitives — `register_function`,
+`register_trigger`, `iii.trigger` — over the engine's WebSocket on port
+49134. There is no agent runtime that lives outside iii.
+
+## Repository layout
+
+```
+agentos/
+├── workers/                Narrow iii workers (one binary each)
+│   ├── agent-core/         ReAct loop                    agent::*
+│   ├── bridge/             External runtime adapters     bridge::*
+│   ├── council/            Proposals + activity log      council::*
+│   ├── directive/          Hierarchical goal alignment   directive::*
+│   ├── embedding/          SentenceTransformers (Python) embedding::*
+│   ├── hierarchy/          Org graph (cycle-safe)        hierarchy::*
+│   ├── ledger/             Budget + spend tracking       ledger::*
+│   ├── llm-router/         Provider routing              llm::*
+│   ├── memory/             Narrow agent memory           memory::*
+│   ├── mission/            Task lifecycle                mission::*
+│   ├── pulse/              Scheduled invocation          pulse::*
+│   ├── realm/              Multi-tenant isolation        realm::*
+│   ├── security/           Combined guardrails + audit   security::*
+│   └── wasm-sandbox/       wasmtime fuel-metered         wasm::*
+│
+├── crates/                 Surfaces (clients, not workers)
+│   ├── cli/                Command-line interface
+│   └── tui/                21-screen terminal dashboard
+│
+├── src/                    TypeScript workers (54 files, ~23k LOC)
+│   └── ...                 a2a, browser, cron, evolve, swarm, etc.
+│
+├── hands/                  Agent personas as TOML config (consumed by hand-runner)
+├── integrations/           MCP server configs as TOML
+├── agents/                 Agent templates as markdown
+│
+├── config.yaml             iii engine boot config (workers: + modules:)
+└── .github/workflows/ci.yml End-to-end CI (build, test, e2e smoke, namespace check)
+```
+
+## Worker manifest
+
+Every directory under `workers/` ships an `iii.worker.yaml` that declares
+its registry shape:
+
+```yaml
+iii: v1
+name: <name>           # must equal the folder name
+language: rust         # rust | python
+deploy: binary         # binary | image
+manifest: Cargo.toml   # Cargo.toml (Rust) | pyproject.toml (Python)
+bin: <cargo-bin-name>  # binary deploys only
+description: ...
+```
+
+CI's `validate iii.worker.yaml` job enforces this on every PR.
+
+## Function namespaces
+
+| namespace | worker | shape |
+|---|---|---|
+| `agent::` | agent-core | `chat`, `create`, `list`, `delete`, `list_tools` |
+| `bridge::` | bridge | `register`, `invoke`, `run`, `list`, `cancel` |
+| `council::` | council | `submit`, `decide`, `override`, `proposals`, `activity`, `verify` |
+| `directive::` | directive | `create`, `get`, `update`, `list`, `ancestry` |
+| `embedding::` | embedding (py) | `generate` |
+| `hierarchy::` | hierarchy | `set`, `tree`, `chain`, `find`, `remove` |
+| `ledger::` | ledger | `set_budget`, `spend`, `check`, `summary` |
+| `llm::` | llm-router | `route`, `complete`, `usage`, `providers` |
+| `memory::` | memory | `store`, `recall`, `consolidate`, `evict`, `delete` |
+| `mission::` | mission | `create`, `list`, `checkout`, `transition`, `comment`, `release` |
+| `pulse::` | pulse | `register`, `tick`, `invoke`, `status`, `toggle` |
+| `realm::` | realm | `create`, `get`, `update`, `delete`, `list`, `import`, `export` |
+| `security::` | security | `audit`, `scan`, `scan_injection`, `check_capability`, `set_capabilities`, `verify_audit`, `docker_exec`, `sign_manifest`, `verify_manifest` |
+| `wasm::` | wasm-sandbox | `execute`, `validate`, `list_modules` |
+
+`sandbox::*` is reserved for the **builtin iii-sandbox** worker (iii
+v0.11.4-next.4), which boots ephemeral microVMs from OCI rootfs.
+AgentOS workers never register under that namespace; the
+`no sandbox::* clash with builtin` CI job enforces this.
+
+## Engine boot
+
+`config.yaml` (iii v0.11.4 schema) declares the seven baseline workers
+the engine spawns: `iii-http`, `iii-state`, `iii-stream`, `iii-queue`,
+`iii-pubsub`, `iii-cron`, `iii-observability`. AgentOS workers are
+spawned alongside as separate processes — each connects to the engine
+WebSocket via `register_worker("ws://localhost:49134", ...)` and stays
+resident.
+
+The engine WebSocket port (49134) is configurable per-worker via the
+`III_WS_URL` environment variable, with `ws://localhost:49134` as the
+default. Containerized deploys override.
+
+## Calling a function from another worker
+
+```rust
+iii.trigger(TriggerRequest {
+    function_id: "memory::recall".to_string(),
+    payload: json!({ "agentId": "alice", "query": "..." }),
+    action: None,
+    timeout_ms: None,
+}).await?
+```
+
+Or fire-and-forget:
+
+```rust
+let iii_c = iii.clone();
+tokio::spawn(async move {
+    let _ = iii_c.trigger(TriggerRequest {
+        function_id: "security::audit".to_string(),
+        payload: json!({ "type": "..." }),
+        action: None,
+        timeout_ms: None,
+    }).await;
+});
+```
+
+This is the only inter-worker contract. There is no shared in-process
+state; everything goes through `iii.trigger`.
+
+## TypeScript workers (src/)
+
+The 54 TypeScript files in `src/` predate the Rust `workers/`
+decomposition. Several are duplicates of Rust workers
+(`src/memory.ts` ↔ `workers/memory`, `src/security.ts` ↔
+`workers/security`, `src/llm-router.ts` ↔ `workers/llm-router`,
+`src/agent-core.ts` ↔ `workers/agent-core`); the rest are TypeScript-
+only features (`a2a`, `swarm`, `eval`, `evolve`, `feedback`,
+`hand-runner`, etc).
+
+Long-term these will collapse into `workers/` as well, with the Rust
+versions becoming canonical for the duplicated domains and the
+TypeScript-only features moving each to `workers/<name>/` with
+`language: node, deploy: image` manifests. That migration is a
+follow-up — not in this iteration.
+
+## Surfaces (cli, tui)
+
+`crates/cli` and `crates/tui` are clients, not workers. They speak
+HTTP to `iii-http` on port 3111. They register no functions and
+declare no `iii.worker.yaml`. Future work should move them onto the
+iii client SDK directly so they call workers via `iii.trigger` instead
+of REST.
+
+## Hands, integrations, agents
+
+These are **declarative config**, not workers:
+
+- `hands/<name>/HAND.toml` — agent persona (system prompt, allowed
+  tools, schedule, dashboard metrics) consumed at runtime by
+  `src/hand-runner.ts`.
+- `integrations/<name>.toml` — MCP server connection details (transport,
+  command, OAuth scopes), consumed by `src/mcp-client.ts`.
+- `agents/<name>/...` — markdown templates for spawning agent
+  personas.
+
+None of these ship as registered functions; they configure workers that
+do.
+
+## Versioning
+
+- iii engine: **v0.11.4-next.4**
+- iii-sdk (Rust): **=0.11.4-next.4** in workspace `Cargo.toml`
+- iii-sdk (Python): **>=0.11.3** in `workers/embedding/pyproject.toml`
+- agentos workspace: `version = "0.0.1"` (reserved for behavioral proof
+  against live infra, not feature completeness)
+
+## CI
+
+Five jobs run on every PR:
+
+| job | gate |
+|---|---|
+| `rust build + test` | `cargo build --release` + `cargo test --workspace` (831 tests) |
+| `validate iii.worker.yaml` | every `workers/<name>/iii.worker.yaml` parses and matches its folder |
+| `no sandbox::* clash with builtin` | grep ensures no agentos worker registers `sandbox::*` |
+| `e2e smoke` | starts engine + 13 workers, asserts ports listen, ≥30 functions register, no namespace clash |
+| `e2e full` | runs vitest e2e suite against the live stack — gated on `AGENTOS_API_KEY` secret |
+
+Plus `.github/workflows/vercel-deploy.yml` (separate workflow): pushes
+to `main` touching `website/**` trigger a Vercel Deploy Hook so the
+docs site stays current with main.
+
+## Dependencies (declarative chain-install)
+
+iii v0.11.4-next.4 added a `dependencies:` map in `iii.worker.yaml`
+that lets `iii worker add ./workers/agent-core` chain-install
+`llm-router`, `memory`, `security` from the registry. AgentOS workers
+do not yet declare deps because they aren't published to the registry
+— once registry publishing lands, agent-core gets:
+
+```yaml
+dependencies:
+  llm-router: ^0.0.1
+  memory: ^0.0.1
+  security: ^0.0.1
+```
+
+## Sandbox primitives — the two distinct surfaces
+
+| namespace | worker | semantics |
+|---|---|---|
+| `sandbox::create` / `sandbox::exec` / `sandbox::list` / `sandbox::stop` | **builtin** iii-sandbox (v0.11.4-next.4) | Ephemeral microVMs booted from OCI rootfs (Python, Node presets). Full Linux. |
+| `wasm::execute` / `wasm::validate` / `wasm::list_modules` | agentos `wasm-sandbox` | wasmtime fuel-metered, instruction-level, sub-millisecond cold start. |
+
+Different cost profiles. The CI namespace-clash job ensures the two
+never collide.
+
+## Atomic state ops (iii v0.11.4)
+
+iii now exposes `state::update` / `stream::update` with `UpdateOp::set`,
+`UpdateOp::increment`, `UpdateOp::append`, plus nested shallow-merge
+paths. Workers should prefer these over `state::list + state::set` race
+patterns when adding to a list or counter.
+
+`council::activity` still uses the manual hash-chain on `state::list +
+state::set` — a separate refactor will move it onto `UpdateOp::append`
+once the chain protocol is redesigned to tolerate concurrent appends
+without compare-and-swap.
+
+## File-by-file responsibilities
+
+For deeper detail on any worker, read its `src/main.rs` (Rust) or
+`main.py` (Python). Each is intentionally small (5-10 registered
+functions, 300-2000 LOC) so it's possible to hold the whole worker in
+your head before touching it.

--- a/workers/embedding/iii.worker.yaml
+++ b/workers/embedding/iii.worker.yaml
@@ -1,0 +1,6 @@
+iii: v1
+name: embedding
+language: python
+deploy: image
+manifest: pyproject.toml
+description: "Text embedding generation via SentenceTransformers (fallback: hash-based)"

--- a/workers/embedding/pyproject.toml
+++ b/workers/embedding/pyproject.toml
@@ -3,7 +3,7 @@ name = "agentos-embedding"
 version = "0.0.1"
 requires-python = ">=3.11"
 dependencies = [
-    "iii-sdk>=0.3.0",
+    "iii-sdk>=0.11.3",
     "sentence-transformers>=2.2.0",
     "torch>=2.0.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
Brings the Python embedding worker up to parity with the 13 Rust workers.

## Changes

- **\`workers/embedding/iii.worker.yaml\`** — canonical manifest with \`language: python\`, \`deploy: image\` (Python workers ship as containers per the iii-hq/workers convention). Worker is now registry-discoverable.
- **\`pyproject.toml\`** — \`iii-sdk>=0.3.0\` → \`iii-sdk>=0.11.3\`. Was pinned to a 2024-era release while the Rust side moved to 0.11.4-next.4 in #35. The \`@iii.function(id=, description=)\` decorator API is unchanged across this bump.
- **CI worker-yaml validator** — drop the \`name == "embedding"\` skip. Every \`workers/<name>/\` directory now requires a manifest, no special cases.

## Verification

\`\`\`
# all 14 worker.yaml files pass validator
ok: agent-core (rust, binary)
ok: bridge (rust, binary)
ok: council (rust, binary)
ok: directive (rust, binary)
ok: embedding (python, image)
ok: hierarchy (rust, binary)
ok: ledger (rust, binary)
ok: llm-router (rust, binary)
ok: memory (rust, binary)
ok: mission (rust, binary)
ok: pulse (rust, binary)
ok: realm (rust, binary)
ok: security (rust, binary)
ok: wasm-sandbox (rust, binary)
\`\`\`

Closes the last gap in the agentos-as-narrow-workers structural goal: every directory under \`workers/\` now has a registry-conformant manifest, and the CI validator enforces it uniformly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedding worker for generating text embeddings using SentenceTransformers.

* **Chores**
  * Updated CI workflow validation to include embedding worker configuration.
  * Updated SDK dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->