### PR TITLE
fix: address CodeRabbit findings on PRs #34, #36, #37, #38, #42, #44

### DIFF
--- a/e2e/full-stack.test.ts
+++ b/e2e/full-stack.test.ts
@@ -13,11 +13,15 @@ let realmId = "";
 let missionId = "";
 let proposalId = "";
 
-async function call<T = unknown>(fn: string, payload: unknown): Promise<T> {
+async function call<T = unknown>(
+  fn: string,
+  payload: unknown,
+  timeoutMs = 30_000,
+): Promise<T> {
   const result = await sdk.trigger({
     function_id: fn,
     payload,
-    timeout_ms: 30_000,
+    timeout_ms: timeoutMs,
   });
   return result as T;
 }
@@ -214,17 +218,21 @@ suite("AgentOS full-stack E2E", () => {
       content: string;
       model: string;
       usage: { input: number; output: number; total: number };
-    }>("llm::complete", {
-      provider: "anthropic",
-      model: "claude-haiku-4-5-20251001",
-      messages: [
-        {
-          role: "user",
-          content: "Reply with the word READY only, no punctuation.",
-        },
-      ],
-      max_tokens: 50,
-    });
+    }>(
+      "llm::complete",
+      {
+        provider: "anthropic",
+        model: "claude-haiku-4-5-20251001",
+        messages: [
+          {
+            role: "user",
+            content: "Reply with the word READY only, no punctuation.",
+          },
+        ],
+        max_tokens: 50,
+      },
+      85_000,
+    );
     expect(r.content.toUpperCase()).toContain("READY");
     expect(r.usage.input).toBeGreaterThan(0);
     expect(r.usage.output).toBeGreaterThan(0);
@@ -241,6 +249,7 @@ suite("AgentOS full-stack E2E", () => {
         agentId: "agent-e2e",
         message: "What is 17 times 23? Reply with just the number.",
       },
+      115_000,
     );
     expect(r.content).toContain("391");
     expect(r.durationMs).toBeGreaterThan(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,6 @@ import { shutdownManager } from "@agentos/shared/shutdown";
 shutdownManager.initShutdown();
 console.log("AgentOS booting (iii-sdk registerWorker API, OTel enabled)");
 
-// Canonical workers for memory, security, llm-router, and agent-core live in
-// workers/ as Rust crates. Their TypeScript duplicates have been removed.
-// Callers should invoke those functions via iii.trigger({ function_id: "memory::store", ... }).
-
 import "./api.js";
 import "./artifact-dag.js";
 import "./lsp-tools.js";

--- a/website/components/CodeExamples.tsx
+++ b/website/components/CodeExamples.tsx
@@ -138,9 +138,11 @@ export default function CodeExamples() {
                 onClick={() => setActive(i)}
                 onKeyDown={(e) => {
                   if (e.key === "ArrowRight") {
-                    selectTab((active + 1) % tabs.length);
+                    e.preventDefault();
+                    selectTab((i + 1) % tabs.length);
                   } else if (e.key === "ArrowLeft") {
-                    selectTab((active - 1 + tabs.length) % tabs.length);
+                    e.preventDefault();
+                    selectTab((i - 1 + tabs.length) % tabs.length);
                   }
                 }}
                 className={`px-4 py-2 text-sm font-mono transition-colors rounded-t-lg ${

--- a/website/components/shared/AnimatedCounter.tsx
+++ b/website/components/shared/AnimatedCounter.tsx
@@ -34,11 +34,13 @@ export default function AnimatedCounter({
 
   useEffect(() => {
     if (!started) return;
+    const safeDuration =
+      Number.isFinite(duration) && duration > 0 ? duration : 1;
     let frameId: number;
     const startTime = performance.now();
     const animate = (now: number) => {
       const elapsed = now - startTime;
-      const progress = Math.min(elapsed / duration, 1);
+      const progress = Math.min(elapsed / safeDuration, 1);
       const eased = 1 - Math.pow(1 - progress, 3);
       setValue(Math.round(eased * end));
       if (progress < 1) frameId = requestAnimationFrame(animate);

--- a/website/components/shared/CodeBlock.tsx
+++ b/website/components/shared/CodeBlock.tsx
@@ -138,11 +138,23 @@ function tokenize(code: string, lang: string): Token[][] {
 function isInsideString(line: string, pos: number): boolean {
   let inSingle = false;
   let inDouble = false;
+  let inTemplate = false;
+  let escaped = false;
   for (let i = 0; i < pos; i++) {
-    if (line[i] === '"' && !inSingle) inDouble = !inDouble;
-    if (line[i] === "'" && !inDouble) inSingle = !inSingle;
+    const ch = line[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"' && !inSingle && !inTemplate) inDouble = !inDouble;
+    else if (ch === "'" && !inDouble && !inTemplate) inSingle = !inSingle;
+    else if (ch === "`" && !inSingle && !inDouble) inTemplate = !inTemplate;
   }
-  return inSingle || inDouble;
+  return inSingle || inDouble || inTemplate;
 }
 
 export default function CodeBlock({
@@ -168,7 +180,13 @@ export default function CodeBlock({
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      timerRef.current = setTimeout(() => setCopied(false), 2000);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+        timerRef.current = null;
+      }, 2000);
     } catch (err) {
       console.error("Clipboard write failed:", err);
     }

--- a/website/index.html
+++ b/website/index.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AgentOS — The Agent Operating System</title>
-    <meta name="description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,506 tests. Rust + TypeScript + Python." />
+    <meta name="description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,727 tests. Rust + TypeScript + Python." />
     <meta property="og:title" content="AgentOS — The Agent Operating System" />
-    <meta property="og:description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,506 tests." />
+    <meta property="og:description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,727 tests." />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="AgentOS — The Agent Operating System" />
-    <meta name="twitter:description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,506 tests." />
+    <meta name="twitter:description" content="AI agent operating system built on iii-engine. 60+ tools, 25 LLM providers, 40 channels, 45 agents, 2,727 tests." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/workers/agent-core/src/main.rs
+++ b/workers/agent-core/src/main.rs
@@ -79,12 +79,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RegisterFunction::new_async("agent::delete", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
-                let agent_id = input["agentId"].as_str().unwrap_or("");
+                let agent_id = input["agentId"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| IIIError::Handler("missing or empty agentId".into()))?
+                    .to_string();
                 iii.trigger(TriggerRequest {
                     function_id: "state::delete".to_string(),
                     payload: json!({
                     "scope": "agents",
-                    "key": agent_id,
+                    "key": &agent_id,
                 }),
                     action: None,
                     timeout_ms: None,
@@ -94,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let _iii = iii.clone();
                     let _payload = json!({
                     "topic": "agent.lifecycle",
-                    "data": { "type": "deleted", "agentId": agent_id },
+                    "data": { "type": "deleted", "agentId": &agent_id },
                 });
                     tokio::spawn(async move {
                         let _ = _iii.trigger(TriggerRequest {
@@ -338,25 +342,24 @@ async fn agent_chat(iii: &III, req: ChatRequest) -> Result<Value, IIIError> {
         });
     };
 
-    let _ = {
-        let _iii = iii.clone();
-        let _payload = json!({
-        "scope": "metering",
-        "key": &req.agent_id,
-        "operations": [
-            { "type": "increment", "path": "totalTokens", "value": response["usage"]["total"] },
-            { "type": "increment", "path": "invocations", "value": 1 },
-        ],
-    });
-        tokio::spawn(async move {
-            let _ = _iii.trigger(TriggerRequest {
-                function_id: "state::update".to_string(),
-                payload: _payload,
-                action: None,
-                timeout_ms: None,
-            }).await;
-        });
-    };
+    if let Err(e) = iii
+        .trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
+                "scope": "metering",
+                "key": &req.agent_id,
+                "operations": [
+                    { "type": "increment", "path": "totalTokens", "value": response["usage"]["total"] },
+                    { "type": "increment", "path": "invocations", "value": 1 },
+                ],
+            }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+    {
+        tracing::warn!(agent_id = %req.agent_id, error = %e, "metering update failed");
+    }
 
     Ok(json!({
         "content": response.get("content").and_then(|v| v.as_str()).unwrap_or(""),

--- a/workers/bridge/src/main.rs
+++ b/workers/bridge/src/main.rs
@@ -145,7 +145,7 @@ async fn invoke_runtime(
         };
 
         let val = serde_json::to_value(&finished_run).unwrap();
-        let _ = iii_bg.trigger(TriggerRequest {
+        if let Err(e) = iii_bg.trigger(TriggerRequest {
             function_id: "state::set".to_string(),
             payload: json!({
             "scope": runs_scope(),
@@ -155,7 +155,10 @@ async fn invoke_runtime(
             action: None,
             timeout_ms: None,
         })
-        .await;
+        .await
+        {
+            tracing::error!(run_id = %run_id_bg, error = %e, "failed to persist terminal run state");
+        }
 
         let _ = {
             let _iii = iii_bg.clone();
@@ -270,7 +273,7 @@ async fn cancel_run(
     if let Some((_, handle)) = active_runs.remove(&req.run_id) {
         handle.abort();
 
-        let _ = iii.trigger(TriggerRequest {
+        iii.trigger(TriggerRequest {
             function_id: "state::update".to_string(),
             payload: json!({
             "scope": runs_scope(),
@@ -281,7 +284,8 @@ async fn cancel_run(
             action: None,
             timeout_ms: None,
         })
-        .await;
+        .await
+        .map_err(|e| IIIError::Handler(format!("failed to mark run {} as cancelled: {e}", req.run_id)))?;
 
         Ok(json!({ "cancelled": true, "runId": req.run_id }))
     } else {

--- a/workers/llm-router/src/main.rs
+++ b/workers/llm-router/src/main.rs
@@ -120,6 +120,8 @@ async fn call_anthropic(
         .send()
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| IIIError::Handler(e.to_string()))?
         .json::<Value>()
         .await
         .map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -155,6 +157,8 @@ async fn call_openai_compat(
     let resp = req.json(&body)
         .send()
         .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?
+        .error_for_status()
         .map_err(|e| IIIError::Handler(e.to_string()))?
         .json::<Value>()
         .await

--- a/workers/pulse/src/main.rs
+++ b/workers/pulse/src/main.rs
@@ -107,34 +107,33 @@ async fn register_pulse(iii: &III, req: RegisterPulseRequest) -> Result<Value, I
     let value = serde_json::to_value(&config).map_err(|e| IIIError::Handler(e.to_string()))?;
 
     iii.trigger(TriggerRequest {
+        function_id: "engine::triggers::register".to_string(),
+        payload: json!({
+            "type": "cron",
+            "function": "pulse::tick",
+            "config": {
+                "schedule": &req.cron,
+                "data": { "agentId": &req.agent_id, "realmId": &req.realm_id },
+            },
+        }),
+        action: None,
+        timeout_ms: None,
+    })
+    .await
+    .map_err(|e| IIIError::Handler(format!("failed to register cron trigger: {e}")))?;
+
+    iii.trigger(TriggerRequest {
         function_id: "state::set".to_string(),
         payload: json!({
-        "scope": config_scope(&req.realm_id),
-        "key": &req.agent_id,
-        "value": value,
-    }),
+            "scope": config_scope(&req.realm_id),
+            "key": &req.agent_id,
+            "value": value,
+        }),
         action: None,
         timeout_ms: None,
     })
     .await
     .map_err(|e| IIIError::Handler(e.to_string()))?;
-
-    let _ = iii
-        .trigger(TriggerRequest {
-            function_id: "engine::triggers::register".to_string(),
-            payload: json!({
-            "type": "cron",
-            "function": "pulse::tick",
-            "config": {
-                "schedule": req.cron,
-                "data": { "agentId": req.agent_id, "realmId": req.realm_id },
-            },
-        }),
-            action: None,
-            timeout_ms: None,
-        })
-        .await
-        .map_err(|e| IIIError::Handler(format!("failed to register cron trigger: {e}")))?;
 
     Ok(serde_json::to_value(&config).unwrap())
 }

--- a/workers/security/src/main.rs
+++ b/workers/security/src/main.rs
@@ -96,22 +96,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     timeout_ms: None,
                 }).await.map_err(|e| IIIError::Handler(e.to_string()))?;
 
-                {
-                    let _iii = iii.clone();
-                    let _payload = json!({
-                    "type": "capabilities_updated",
-                    "agentId": agent_id,
-                    "detail": { "tools": caps["tools"].as_array().map(|a| a.len()).unwrap_or(0) },
-                });
-                    tokio::spawn(async move {
-                        let _ = _iii.trigger(TriggerRequest {
-                            function_id: "security::audit".to_string(),
-                            payload: _payload,
-                            action: None,
-                            timeout_ms: None,
-                        }).await;
-                    });
-                };
+                iii.trigger(TriggerRequest {
+                    function_id: "security::audit".to_string(),
+                    payload: json!({
+                        "type": "capabilities_updated",
+                        "agentId": agent_id,
+                        "detail": { "tools": caps["tools"].as_array().map(|a| a.len()).unwrap_or(0) },
+                    }),
+                    action: None,
+                    timeout_ms: None,
+                })
+                .await
+                .map_err(|e| IIIError::Handler(format!("audit emission failed: {e}")))?;
 
                 Ok::<Value, IIIError>(json!({ "updated": true }))
             }
@@ -217,22 +213,21 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
     let allowed = tools.iter().any(|t| *t == "*" || resource.starts_with(t));
 
     if !allowed {
+        if let Err(e) = iii
+            .trigger(TriggerRequest {
+                function_id: "security::audit".to_string(),
+                payload: json!({
+                    "type": "capability_denied",
+                    "agentId": agent_id,
+                    "detail": { "resource": resource, "reason": "tool_not_allowed" },
+                }),
+                action: None,
+                timeout_ms: None,
+            })
+            .await
         {
-            let _iii = iii.clone();
-            let _payload = json!({
-            "type": "capability_denied",
-            "agentId": agent_id,
-            "detail": { "resource": resource, "reason": "tool_not_allowed" },
-        });
-            tokio::spawn(async move {
-                let _ = _iii.trigger(TriggerRequest {
-                    function_id: "security::audit".to_string(),
-                    payload: _payload,
-                    action: None,
-                    timeout_ms: None,
-                }).await;
-            });
-        };
+            tracing::error!(agent_id = %agent_id, error = %e, "audit emission failed for capability_denied");
+        }
         return Err(IIIError::Handler(format!("Agent {} denied: {}", agent_id, resource)));
     }
 
@@ -250,22 +245,21 @@ async fn check_capability(iii: &III, input: Value) -> Result<Value, IIIError> {
 
         let used = usage["totalTokens"].as_u64().unwrap_or(0);
         if used > max_tokens {
+            if let Err(e) = iii
+                .trigger(TriggerRequest {
+                    function_id: "security::audit".to_string(),
+                    payload: json!({
+                        "type": "quota_exceeded",
+                        "agentId": agent_id,
+                        "detail": { "used": used, "limit": max_tokens },
+                    }),
+                    action: None,
+                    timeout_ms: None,
+                })
+                .await
             {
-                let _iii = iii.clone();
-                let _payload = json!({
-                "type": "quota_exceeded",
-                "agentId": agent_id,
-                "detail": { "used": used, "limit": max_tokens },
-            });
-                tokio::spawn(async move {
-                    let _ = _iii.trigger(TriggerRequest {
-                        function_id: "security::audit".to_string(),
-                        payload: _payload,
-                        action: None,
-                        timeout_ms: None,
-                    }).await;
-                });
-            };
+                tracing::error!(agent_id = %agent_id, error = %e, "audit emission failed for quota_exceeded");
+            }
             return Err(IIIError::Handler(format!("Agent {} exceeded token quota", agent_id)));
         }
     }


### PR DESCRIPTION
Consolidates CodeRabbit findings from earlier merged PRs into a single follow-up. Touches only the workers in this agent's lane (agent-core, bridge, council, directive, hierarchy, ledger, llm-router, memory, mission, pulse, realm, security, wasm-sandbox), website, e2e, and src/index.ts.

## Outcome by PR

### PR #34 (2 findings)
- README embedding worker dedupe — already resolved in 59d92e3
- wasm-sandbox manifest description quote — already resolved in 59d92e3

### PR #36 (2 findings)
- llm-router Anthropic text-block scan — already resolved in 0e50485
- llm-router error_for_status on send chains — **fixed** (call_anthropic, call_openai_compat)

### PR #37 (14 findings)
Already resolved in 18d1dd9: CodeExamples flow key, Quickstart timer cleanup, CodeBlock useRef typing, FadeIn reduced-motion init, twitter:card meta.
- CodeExamples ArrowLeft/Right uses active vs focused index — **fixed** (use `i`, preventDefault)
- AnimatedCounter clamps non-finite/<=0 duration — **fixed**
- CodeBlock isInsideString tracks escapes and template literals — **fixed**
- CodeBlock copy clears prior timeout — **fixed**
- index.html test count vs stats.ts mismatch — **fixed** (aligned to 2,727)
- .js extension on relative imports (App.tsx, Compare.tsx, Hero.tsx, SectionHeader.tsx) — **deferred**: this is a Vite project with `moduleResolution: bundler` and `allowImportingTsExtensions: true`; adding `.js` to `.tsx` source paths would break dev/build.

### PR #38 (11 findings)
- agent-core metering best-effort spawn — **fixed** (awaited; logs on failure)
- agent-core agent::delete empty id — **fixed** (validates non-empty)
- bridge terminal state::set error swallowed — **fixed** (logs on failure)
- bridge cancellation state::update error swallowed — **fixed** (propagates as IIIError)
- pulse persists config before cron registers — **fixed** (reordered)
- security audit emission detached spawn (capabilities_updated, capability_denied, quota_exceeded) — **fixed** (awaited)
- security/wasm-sandbox HTTP trigger uses api_path/http_method — **incorrect finding**: iii-sdk 0.11.4-next.4 uses these as the canonical keys (verified against SDK tests). All workers in the repo use this form.
- council activity-chain race (CAS append) — **deferred**: iii-sdk does not expose `expectedVersion` for `state::set`; would need SDK support.
- mission::checkout CAS — **deferred**: same SDK gap.
- realm::delete cascade — **deferred**: requires prefix-delete trigger or full key enumeration; non-trivial scope.

### PR #42 (1 finding)
- e2e call() hard-coded 30s timeout — **fixed** (helper accepts override; llm::complete passes 85s, agent::chat passes 115s)

### PR #44 (1 finding)
- src/index.ts migration comment — **fixed** (removed)

## Counts
- Fixed: 17
- Already resolved: 7
- Deferred (SDK gap or out of scope): 4
- Incorrect findings: 2 (api_path/http_method false positives)

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --release` passes
- [x] `npx vitest run` passes (1308 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed keyboard navigation for code example tabs to respond to arrow key input
  * Resolved animation duration validation to handle invalid values gracefully
  * Improved comment detection in code blocks to correctly identify template literals
  * Fixed copy-to-clipboard indicator to prevent stale timer issues
  * Added HTTP status validation for LLM API requests
  * Enhanced error handling and reporting across services

* **New Features**
  * Added configurable timeout support for critical operations

* **Chores**
  * Updated website metrics to reflect current test count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->