### PR TITLE
fix(rate-limiter, loop-guard, hashline, hooks): address CodeRabbit findings on PR #49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "agentos-a2a"
 version = "0.0.1"
 dependencies = [
@@ -57,6 +92,23 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "agentos-channel-slack"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "hex",
+ "hmac",
+ "iii-sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -131,6 +183,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentos-cron"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "agentos-directive"
 version = "0.0.1"
 dependencies = [
@@ -154,6 +221,7 @@ dependencies = [
  "iii-sdk",
  "serde",
  "serde_json",
+ "similar",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -346,6 +414,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentos-telemetry"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "sysinfo 0.32.1",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "agentos-tui"
 version = "0.0.1"
 dependencies = [
@@ -358,6 +442,25 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "agentos-vault"
+version = "0.0.1"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "base64",
+ "chrono",
+ "iii-sdk",
+ "rand 0.8.6",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -586,6 +689,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -945,7 +1058,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1413,6 +1536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1757,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1768,7 +1901,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sysinfo",
+ "sysinfo 0.38.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -1822,6 +1955,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2118,6 +2260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,7 +2326,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2214,10 +2362,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2284,6 +2453,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,8 +2527,8 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -2428,7 +2609,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2471,12 +2652,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2791,6 +2993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,6 +3039,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "security-framework"
@@ -3043,6 +3266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3395,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
@@ -3175,7 +3418,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3598,7 +3841,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3658,6 +3901,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4322,12 +4575,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -4338,7 +4601,19 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4347,10 +4622,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -4360,9 +4635,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4370,6 +4656,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4399,8 +4696,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/workers/hashline/Cargo.toml
+++ b/workers/hashline/Cargo.toml
@@ -17,3 +17,4 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 chrono.workspace = true
+similar = "2"

--- a/workers/hashline/src/main.rs
+++ b/workers/hashline/src/main.rs
@@ -33,13 +33,12 @@ pub fn compute_line_hash(line_number: i64, content: &str) -> String {
     let seed: i32 = if has_alnum { 0 } else { line_number as i32 };
 
     let mut hash: i32 = 0;
-    for ch in stripped.chars() {
-        // JS: charCodeAt returns UTF-16 code unit. For BMP chars this equals u32 code point;
-        // for non-BMP it's a surrogate. For ASCII source we mimic with u32 codepoints.
-        let code = ch as u32 as i32;
+    // Iterate UTF-16 code units to match JS `charCodeAt()` semantics so non-BMP
+    // characters (emoji, astral plane) produce the same hash as the TS reference.
+    for unit in stripped.encode_utf16() {
+        let code = unit as i32;
         let shifted = hash.wrapping_shl(5);
         hash = shifted.wrapping_sub(hash).wrapping_add(code).wrapping_add(seed);
-        // `| 0` is a no-op for i32 wrapping arithmetic since result is already 32-bit.
     }
     let unsigned = hash as u32;
     let idx = (unsigned % 256) as usize;
@@ -113,21 +112,26 @@ struct EditInput {
     lines: Value,
 }
 
-fn normalize_edit_lines(v: &Value) -> Option<Vec<String>> {
+fn normalize_edit_lines(v: &Value) -> Result<Option<Vec<String>>, IIIError> {
     if v.is_null() {
-        return None;
+        return Ok(None);
     }
     if let Some(s) = v.as_str() {
-        return Some(s.split('\n').map(String::from).collect());
+        return Ok(Some(s.split('\n').map(String::from).collect()));
     }
     if let Some(arr) = v.as_array() {
-        return Some(
-            arr.iter()
-                .map(|x| x.as_str().unwrap_or("").to_string())
-                .collect(),
-        );
+        let mut out = Vec::with_capacity(arr.len());
+        for x in arr {
+            let s = x.as_str().ok_or_else(|| {
+                IIIError::Handler("edit lines array must contain only strings".into())
+            })?;
+            out.push(s.to_string());
+        }
+        return Ok(Some(out));
     }
-    None
+    Err(IIIError::Handler(
+        "edit lines must be a string, string array, or null".into(),
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -152,7 +156,7 @@ fn parse_edits(edits: &[EditInput]) -> Result<Vec<ParsedEdit>, IIIError> {
             None => None,
         };
         let lines_present = !e.lines.is_null();
-        let lines = normalize_edit_lines(&e.lines);
+        let lines = normalize_edit_lines(&e.lines)?;
         parsed.push(ParsedEdit {
             op: e.op.clone(),
             pos,
@@ -341,6 +345,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let resolved = workspace_root().join(&path);
                 assert_path_contained(&resolved)?;
 
+                // CONSISTENCY MODEL: hashline_edit assumes single-writer
+                // semantics. The hash anchor check rejects edits that don't
+                // match the current content, so two concurrent edits cannot
+                // both succeed against the same line — the second write will
+                // mismatch. Cross-process file locking (e.g. flock) is a
+                // separate concern tracked in CR PR #49 (hashline:355).
                 let content = tokio::fs::read_to_string(&resolved)
                     .await
                     .map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -422,30 +432,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let parsed = parse_edits(&edits)?;
                 let edited_lines = apply_edits(&original_lines, &parsed)?;
 
-                let mut diff = Vec::new();
-                let mut i = 0usize;
-                let mut j = 0usize;
-                while i < original_lines.len() || j < edited_lines.len() {
-                    if i < original_lines.len() && j < edited_lines.len() {
-                        if original_lines[i] == edited_lines[j] {
-                            diff.push(format!(" {}", original_lines[i]));
-                            i += 1;
-                            j += 1;
-                        } else {
-                            diff.push(format!("-{}", original_lines[i]));
-                            i += 1;
-                            if j < edited_lines.len() {
-                                diff.push(format!("+{}", edited_lines[j]));
-                                j += 1;
-                            }
-                        }
-                    } else if i < original_lines.len() {
-                        diff.push(format!("-{}", original_lines[i]));
-                        i += 1;
-                    } else {
-                        diff.push(format!("+{}", edited_lines[j]));
-                        j += 1;
-                    }
+                // Use a proper LCS-based diff so insertions/deletions don't
+                // misalign the rest of the file (lockstep walking is incorrect).
+                let original_refs: Vec<&str> =
+                    original_lines.iter().map(String::as_str).collect();
+                let edited_refs: Vec<&str> =
+                    edited_lines.iter().map(String::as_str).collect();
+                let diff_engine = similar::TextDiff::from_slices(&original_refs, &edited_refs);
+                let mut diff: Vec<String> = Vec::new();
+                for change in diff_engine.iter_all_changes() {
+                    let line = change.value();
+                    let entry = match change.tag() {
+                        similar::ChangeTag::Equal => format!(" {line}"),
+                        similar::ChangeTag::Delete => format!("-{line}"),
+                        similar::ChangeTag::Insert => format!("+{line}"),
+                    };
+                    diff.push(entry);
                 }
 
                 let _ = _iii.trigger(TriggerRequest {
@@ -702,12 +704,24 @@ mod tests {
     #[test]
     fn normalize_edit_lines_string_splits_on_newline() {
         let v = json!("a\nb\nc");
-        let out = normalize_edit_lines(&v).unwrap();
+        let out = normalize_edit_lines(&v).unwrap().unwrap();
         assert_eq!(out, vec!["a", "b", "c"]);
     }
 
     #[test]
     fn normalize_edit_lines_null_returns_none() {
-        assert!(normalize_edit_lines(&Value::Null).is_none());
+        assert!(normalize_edit_lines(&Value::Null).unwrap().is_none());
+    }
+
+    #[test]
+    fn normalize_edit_lines_rejects_non_string_array_element() {
+        let v = json!(["ok", 42]);
+        assert!(normalize_edit_lines(&v).is_err());
+    }
+
+    #[test]
+    fn normalize_edit_lines_rejects_object() {
+        let v = json!({ "not": "valid" });
+        assert!(normalize_edit_lines(&v).is_err());
     }
 }

--- a/workers/hooks/src/main.rs
+++ b/workers/hooks/src/main.rs
@@ -42,7 +42,7 @@ fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
-async fn state_get(iii: &III, scope: &str, key: &str) -> Option<Value> {
+async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {
     let res = iii
         .trigger(TriggerRequest {
             function_id: "state::get".to_string(),
@@ -51,21 +51,21 @@ async fn state_get(iii: &III, scope: &str, key: &str) -> Option<Value> {
             timeout_ms: None,
         })
         .await
-        .ok()?;
-    if res.is_null() { None } else { Some(res) }
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(if res.is_null() { None } else { Some(res) })
 }
 
-async fn state_list(iii: &III, scope: &str) -> Vec<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::list".to_string(),
-        payload: json!({ "scope": scope }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .and_then(|v| v.as_array().cloned())
-    .unwrap_or_default()
+async fn state_list(iii: &III, scope: &str) -> Result<Vec<Value>, IIIError> {
+    let res = iii
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(res.as_array().cloned().unwrap_or_default())
 }
 
 async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<(), IIIError> {
@@ -107,8 +107,8 @@ fn fire_and_forget(iii: &III, function_id: &str, payload: Value) {
     });
 }
 
-async fn load_hooks(iii: &III) -> Vec<HookDefinition> {
-    let entries = state_list(iii, "hooks").await;
+async fn load_hooks(iii: &III) -> Result<Vec<HookDefinition>, IIIError> {
+    let entries = state_list(iii, "hooks").await?;
     let mut out = Vec::new();
     for e in entries {
         // entries can be either {key, value} or just the value, depending on engine
@@ -119,7 +119,7 @@ async fn load_hooks(iii: &III) -> Vec<HookDefinition> {
             }
         }
     }
-    out
+    Ok(out)
 }
 
 async fn save_hook(iii: &III, hook: &HookDefinition) -> Result<(), IIIError> {
@@ -162,6 +162,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let priority = input["priority"].as_i64().unwrap_or(100);
                 let agent_id = input["agentId"].as_str().map(String::from);
                 let filter = input.get("filter").cloned().filter(|v| !v.is_null());
+
+                // Validate tool-call filter shape up front so hook::fire can
+                // trust filter.toolIds is an array of strings (or absent).
+                let is_tool_call =
+                    matches!(hook_type.as_str(), "BeforeToolCall" | "AfterToolCall");
+                if let (true, Some(tool_ids)) = (
+                    is_tool_call,
+                    filter.as_ref().and_then(|f| f.get("toolIds")),
+                ) {
+                    let arr = tool_ids.as_array().ok_or_else(|| {
+                        IIIError::Handler("filter.toolIds must be an array of strings".into())
+                    })?;
+                    if !arr.iter().all(|v| v.is_string()) {
+                        return Err(IIIError::Handler(
+                            "filter.toolIds must contain only strings".into(),
+                        ));
+                    }
+                }
 
                 let hook = HookDefinition {
                     id: hook_id.clone(),
@@ -209,7 +227,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_ref.clone();
             async move {
                 let hook_id = input["hookId"].as_str().unwrap_or("").to_string();
-                let raw = state_get(&iii, "hooks", &hook_id).await;
+                let raw = state_get(&iii, "hooks", &hook_id).await?;
                 let hook: HookDefinition = match raw.and_then(|v| serde_json::from_value(v).ok()) {
                     Some(h) => h,
                     None => {
@@ -247,7 +265,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let payload = input.get("payload").cloned().unwrap_or(json!({}));
                 let agent_id = input["agentId"].as_str().map(String::from);
 
-                let all_hooks = load_hooks(&iii).await;
+                let all_hooks = load_hooks(&iii).await?;
 
                 let payload_agent_id = payload.get("agentId").and_then(|v| v.as_str()).map(String::from);
 
@@ -373,7 +391,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let agent_id_filter = input.get("agentId").and_then(|v| v.as_str()).map(String::from);
                 let enabled_only = input.get("enabledOnly").and_then(|v| v.as_bool()).unwrap_or(false);
 
-                let mut hooks = load_hooks(&iii).await;
+                let mut hooks = load_hooks(&iii).await?;
                 if let Some(t) = &type_filter {
                     hooks.retain(|h| h.hook_type == *t);
                 }
@@ -425,9 +443,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_ref.clone();
             async move {
                 let hook_id = input["hookId"].as_str().unwrap_or("").to_string();
-                let enabled = input["enabled"].as_bool().unwrap_or(false);
+                let enabled = input
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .ok_or_else(|| IIIError::Handler("enabled must be a boolean".into()))?;
 
-                let raw = state_get(&iii, "hooks", &hook_id).await;
+                let raw = state_get(&iii, "hooks", &hook_id).await?;
                 let mut hook: HookDefinition = match raw.and_then(|v| serde_json::from_value(v).ok()) {
                     Some(h) => h,
                     None => {
@@ -455,9 +476,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_ref.clone();
             async move {
                 let hook_id = input["hookId"].as_str().unwrap_or("").to_string();
-                let priority = input["priority"].as_i64().unwrap_or(100);
+                let priority = input
+                    .get("priority")
+                    .and_then(Value::as_i64)
+                    .ok_or_else(|| IIIError::Handler("priority must be an integer".into()))?;
 
-                let raw = state_get(&iii, "hooks", &hook_id).await;
+                let raw = state_get(&iii, "hooks", &hook_id).await?;
                 let mut hook: HookDefinition = match raw.and_then(|v| serde_json::from_value(v).ok()) {
                     Some(h) => h,
                     None => {

--- a/workers/loop-guard/src/main.rs
+++ b/workers/loop-guard/src/main.rs
@@ -116,6 +116,34 @@ async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<()
     Ok(())
 }
 
+/// Atomic increment of an integer counter at scope/key. Returns the post-increment value.
+async fn state_increment(
+    iii: &III,
+    scope: &str,
+    key: &str,
+    delta: i64,
+) -> Result<i64, IIIError> {
+    let res = iii
+        .trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
+                "scope": scope,
+                "key": key,
+                "operations": [
+                    { "type": "increment", "path": "", "value": delta },
+                ],
+            }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(res
+        .as_i64()
+        .or_else(|| res.get("value").and_then(|v| v.as_i64()))
+        .unwrap_or(0))
+}
+
 async fn get_agent_index(iii: &III) -> Vec<String> {
     state_get(iii, "loop_guard_history", "_index")
         .await
@@ -208,12 +236,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let params = input.get("params").cloned().unwrap_or(json!({}));
                 let result_hash = input["resultHash"].as_str().map(String::from);
 
-                let prev_calls = state_get(&iii, "loop_guard_counts", &agent_id)
-                    .await
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                let agent_calls = prev_calls + 1;
-                state_set(&iii, "loop_guard_counts", &agent_id, json!(agent_calls)).await?;
+                // Atomic increment so overlapping guard::check calls each see a unique
+                // post-increment value rather than racing on a read-modify-write.
+                let agent_calls = state_increment(&iii, "loop_guard_counts", &agent_id, 1).await?;
 
                 if agent_calls > PER_AGENT_CIRCUIT_BREAKER {
                     return Ok::<Value, IIIError>(json!({
@@ -303,18 +328,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 if identical_count >= warn_at {
                     let bucket_key = format!("{agent_id}:{call_hash}");
-                    let prev_warnings = state_get(&iii, "loop_guard_warnings", &bucket_key)
-                        .await
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    let warnings = prev_warnings + 1;
-                    state_set(
-                        &iii,
-                        "loop_guard_warnings",
-                        &bucket_key,
-                        json!(warnings),
-                    )
-                    .await?;
+                    // Atomic increment to avoid lost warnings under concurrent checks.
+                    let warnings =
+                        state_increment(&iii, "loop_guard_warnings", &bucket_key, 1).await?;
 
                     let mut warn_keys = get_warning_keys(&iii, &agent_id).await;
                     if !warn_keys.contains(&bucket_key) {

--- a/workers/rate-limiter/src/main.rs
+++ b/workers/rate-limiter/src/main.rs
@@ -123,25 +123,20 @@ fn gcra_compute(
 ) -> (RateCheckResult, Option<GcraState>) {
     let increment = cost * emission_interval_ms;
 
-    if state.is_none() {
-        let new_tat = now + increment;
-        let new_state = GcraState {
-            tat: new_tat,
-            tokens: (burst_limit - cost) as i64,
-        };
+    if cost > burst_limit {
+        let retry_after_secs = ((cost - burst_limit) * emission_interval_ms / 1000.0).ceil() as i64;
         return (
             RateCheckResult {
-                allowed: true,
-                remaining: (burst_limit - cost) as i64,
-                retry_after: None,
+                allowed: false,
+                remaining: 0,
+                retry_after: Some(retry_after_secs.max(1)),
                 limit: tokens_per_minute,
             },
-            Some(new_state),
+            None,
         );
     }
 
-    let state = state.unwrap();
-    let tat = state.tat.max(now);
+    let tat = state.map(|s| s.tat).unwrap_or(now).max(now);
     let new_tat = tat + increment;
     let allow_at = new_tat - burst_limit * emission_interval_ms;
 
@@ -277,7 +272,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let remaining = (((BURST_LIMIT * EMISSION_INTERVAL_MS - (s.tat - now))
                         / EMISSION_INTERVAL_MS)
                         .floor() as i64)
-                        .max(0);
+                        .clamp(0, TOKENS_PER_MINUTE as i64);
                     Ok::<Value, IIIError>(json!({
                         "ip": ip,
                         "remaining": remaining,
@@ -411,27 +406,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .as_i64()
                     .filter(|v| *v > 0)
                     .unwrap_or(DEFAULT_AGENT_MAX_CONCURRENT);
-                let current = state_get(&iii, "rate_concurrent", &agent_id)
+
+                // Atomic increment via state::update.
+                let updated = iii
+                    .trigger(TriggerRequest {
+                        function_id: "state::update".to_string(),
+                        payload: json!({
+                            "scope": "rate_concurrent",
+                            "key": &agent_id,
+                            "operations": [
+                                { "type": "increment", "path": "", "value": 1 },
+                            ],
+                        }),
+                        action: None,
+                        timeout_ms: None,
+                    })
                     .await
-                    .and_then(|v| v.as_i64())
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                let new_count = updated
+                    .as_i64()
+                    .or_else(|| updated.get("value").and_then(|v| v.as_i64()))
                     .unwrap_or(0);
-                if current >= limit {
+
+                if new_count > limit {
+                    // Roll back the speculative increment.
+                    let _ = iii
+                        .trigger(TriggerRequest {
+                            function_id: "state::update".to_string(),
+                            payload: json!({
+                                "scope": "rate_concurrent",
+                                "key": &agent_id,
+                                "operations": [
+                                    { "type": "increment", "path": "", "value": -1 },
+                                ],
+                            }),
+                            action: None,
+                            timeout_ms: None,
+                        })
+                        .await;
                     return Ok::<Value, IIIError>(json!({
                         "acquired": false,
-                        "current": current,
+                        "current": new_count - 1,
                         "limit": limit,
                     }));
                 }
-                state_set(
-                    &iii,
-                    "rate_concurrent",
-                    &agent_id,
-                    json!(current + 1),
-                )
-                .await?;
+
                 Ok::<Value, IIIError>(json!({
                     "acquired": true,
-                    "current": current + 1,
+                    "current": new_count,
                     "limit": limit,
                 }))
             }
@@ -445,13 +468,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let iii = iii_ref.clone();
             async move {
                 let agent_id = input["agentId"].as_str().unwrap_or("").to_string();
-                let current = state_get(&iii, "rate_concurrent", &agent_id)
+
+                // Atomic decrement via state::update; clamp to zero afterwards.
+                let updated = iii
+                    .trigger(TriggerRequest {
+                        function_id: "state::update".to_string(),
+                        payload: json!({
+                            "scope": "rate_concurrent",
+                            "key": &agent_id,
+                            "operations": [
+                                { "type": "increment", "path": "", "value": -1 },
+                            ],
+                        }),
+                        action: None,
+                        timeout_ms: None,
+                    })
                     .await
-                    .and_then(|v| v.as_i64())
+                    .map_err(|e| IIIError::Handler(e.to_string()))?;
+
+                let new_count = updated
+                    .as_i64()
+                    .or_else(|| updated.get("value").and_then(|v| v.as_i64()))
                     .unwrap_or(0);
-                let next = (current - 1).max(0);
-                state_set(&iii, "rate_concurrent", &agent_id, json!(next)).await?;
-                Ok::<Value, IIIError>(json!({ "released": true, "current": next }))
+
+                if new_count < 0 {
+                    // Counter underflow — clamp by setting to zero.
+                    state_set(&iii, "rate_concurrent", &agent_id, json!(0)).await?;
+                    return Ok::<Value, IIIError>(json!({ "released": true, "current": 0 }));
+                }
+
+                Ok::<Value, IIIError>(json!({ "released": true, "current": new_count }))
             }
         })
         .description("Release concurrent invocation slot for an agent"),
@@ -635,11 +681,12 @@ mod tests {
     }
 
     #[test]
-    fn very_large_cost_first_request() {
+    fn over_burst_first_request_rejected() {
         let mut state = None;
         let r = check(&mut state, 10000.0, 1000.0);
-        assert!(r.allowed);
-        assert_eq!(r.remaining, (BURST_LIMIT as i64) - 10000);
+        assert!(!r.allowed);
+        assert_eq!(r.remaining, 0);
+        assert!(r.retry_after.is_some());
     }
 
     #[test]


### PR DESCRIPTION
Addresses 11 CodeRabbit findings on the merged [PR #49](https://github.com/iii-experimental/agentos/pull/49).

## Summary by severity

### Critical (1 fixed)
- **rate-limiter**: concurrency counter races (acquire/release via `state::update` increment) — `workers/rate-limiter/src/main.rs:431,448-453` — **fixed**

### Major (8 fixed, 1 deferred)
- **rate-limiter**: over-capacity request always allowed on first hit — `:140` — **fixed** (reject when `cost > burst_limit`)
- **loop-guard**: concurrent `guard::check` overlapping read-modify-writes — `:253,304-323` — **fixed** (atomic `state::update` for counts + warning buckets)
- **hashline**: `unwrap_or("")` silently coerces malformed edit lines — `:128` — **fixed** (reject non-string entries with handler error)
- **hashline**: read-validate-write race for concurrent `hashline_edit` — `:355` — **deferred with note** (hash anchor check rejects mismatched edits; cross-process file locking is a separate follow-up)
- **hashline**: lockstep diff loop misreports insertions/deletions — `:449` — **fixed** (use `similar = "2"` LCS diff)
- **hooks**: `state::*` errors swallowed, masking backend outages — `:69` — **fixed** (Result-typed helpers, callers propagate via `?`)
- **hooks**: malformed `filter.toolIds` widens hook scope — `:165` — **fixed** (validate shape on register)
- **hooks**: missing `enabled`/`priority` silently defaulted — `:428,457-458` — **fixed** (explicit validation, return `Handler` error)
- **hashline**: `chars()` iteration breaks JS `charCodeAt()` parity for non-BMP — `:41` — **fixed** (`encode_utf16()`)

### Minor (1 fixed)
- **rate-limiter**: `remaining` can grow past `TOKENS_PER_MINUTE` in status — `:287` — **fixed** (`.clamp(0, TOKENS_PER_MINUTE as i64)`)

## Verification

```
cargo check -p agentos-rate-limiter -p agentos-loop-guard -p agentos-hashline -p agentos-hooks
cargo test  -p agentos-rate-limiter -p agentos-loop-guard -p agentos-hashline -p agentos-hooks --release
cargo clippy -p agentos-rate-limiter -p agentos-loop-guard -p agentos-hashline -p agentos-hooks --all-targets -- -D warnings
```

- `cargo check` clean.
- `cargo test --release`: **64 tests pass** across the 4 workers (20+19+19+6). Added 2 new tests for the stricter `normalize_edit_lines` validation. The previous `very_large_cost_first_request` test was renamed to `over_burst_first_request_rejected` to reflect the corrected first-hit behavior.
- `cargo clippy`: no new warnings introduced (matches pre-existing baseline on `main`).

## Constraints honored

- No iii-sdk version bump.
- One new dep: `similar = "2"` on `agentos-hashline` (flagged by CR specifically for the diff fix).
- Atomic `state::update` ops used for race fixes — no `tokio::sync::Mutex`.
- Stay-in-scope: only the four PR #49 workers touched.

## Test plan

- [x] `cargo check --workspace` — all crates compile
- [x] `cargo test --release -p {rate-limiter,loop-guard,hashline,hooks}` — 64/64 green
- [x] `cargo clippy ... -D warnings` — no new findings vs baseline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed hash computation for non-ASCII characters to ensure consistency across platforms
  * Fixed race conditions in concurrent request handling that could cause missed counter increments
  * Improved error handling for invalid hook configurations and filter parameters
  * Fixed potential counter underflow in rate limiting
  * Enhanced validation of tool IDs in hook filters with clearer error messages

* **Improvements**
  * Strengthened state management with atomic operations for better concurrency safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->