### PR TITLE
fix(a2a, swarm, coordination): address CodeRabbit findings on PR #47

### DIFF
--- a/workers/a2a-cards/src/main.rs
+++ b/workers/a2a-cards/src/main.rs
@@ -10,16 +10,17 @@ fn api_url() -> String {
     std::env::var("AGENTOS_API_URL").unwrap_or_else(|_| "http://localhost:3111".to_string())
 }
 
-async fn state_get(iii: &III, scope: &str, key: &str) -> Option<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::get".to_string(),
-        payload: json!({ "scope": scope, "key": key }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .filter(|v| !v.is_null())
+async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {
+    let v = iii
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": scope, "key": key }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(if v.is_null() { None } else { Some(v) })
 }
 
 async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<(), IIIError> {
@@ -34,20 +35,20 @@ async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<()
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
-async fn state_list(iii: &III, scope: &str) -> Vec<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::list".to_string(),
-        payload: json!({ "scope": scope }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .and_then(|v| v.as_array().cloned())
-    .unwrap_or_default()
+async fn state_list(iii: &III, scope: &str) -> Result<Vec<Value>, IIIError> {
+    let v = iii
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(v.as_array().cloned().unwrap_or_default())
 }
 
-async fn list_agent_tools(iii: &III, agent_id: &str) -> Vec<String> {
+async fn list_agent_tools(iii: &III, agent_id: &str) -> Result<Vec<String>, IIIError> {
     let res = iii
         .trigger(TriggerRequest {
             function_id: "agent::list_tools".to_string(),
@@ -55,10 +56,12 @@ async fn list_agent_tools(iii: &III, agent_id: &str) -> Vec<String> {
             action: None,
             timeout_ms: None,
         })
-        .await;
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
 
-    res.ok()
-        .and_then(|v| v.as_array().cloned())
+    Ok(res
+        .as_array()
+        .cloned()
         .map(|arr| {
             arr.iter()
                 .filter_map(|t| {
@@ -69,12 +72,12 @@ async fn list_agent_tools(iii: &III, agent_id: &str) -> Vec<String> {
                 })
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_default()
+        .unwrap_or_default())
 }
 
-async fn list_skill_entries(iii: &III) -> Vec<AgentSkillRef> {
-    let skills = state_list(iii, "skills").await;
-    skills
+async fn list_skill_entries(iii: &III) -> Result<Vec<AgentSkillRef>, IIIError> {
+    let skills = state_list(iii, "skills").await?;
+    Ok(skills
         .into_iter()
         .filter_map(|entry| {
             let s = entry.get("value").cloned().unwrap_or(entry);
@@ -95,16 +98,16 @@ async fn list_skill_entries(iii: &III) -> Vec<AgentSkillRef> {
             Some(AgentSkillRef { id, name, description })
         })
         .take(20)
-        .collect()
+        .collect())
 }
 
 async fn generate_card(iii: &III, req: GenerateCardRequest) -> Result<Value, IIIError> {
     let config = state_get(iii, "agents", &req.agent_id)
-        .await
+        .await?
         .ok_or_else(|| IIIError::Handler(format!("Agent not found: {}", req.agent_id)))?;
 
-    let tool_ids = list_agent_tools(iii, &req.agent_id).await;
-    let skills = list_skill_entries(iii).await;
+    let tool_ids = list_agent_tools(iii, &req.agent_id).await?;
+    let skills = list_skill_entries(iii).await?;
 
     let name = config
         .get("name")
@@ -141,7 +144,7 @@ async fn generate_card(iii: &III, req: GenerateCardRequest) -> Result<Value, III
 }
 
 async fn list_cards(iii: &III) -> Result<Value, IIIError> {
-    let agents = state_list(iii, "agents").await;
+    let agents = state_list(iii, "agents").await?;
     let mut cards: Vec<Value> = Vec::new();
 
     for entry in agents {
@@ -159,7 +162,7 @@ async fn list_cards(iii: &III) -> Result<Value, IIIError> {
 }
 
 async fn well_known(iii: &III) -> Result<Value, IIIError> {
-    if let Some(cached) = state_get(iii, "a2a_cards", "orchestrator").await {
+    if let Some(cached) = state_get(iii, "a2a_cards", "orchestrator").await? {
         return Ok::<Value, IIIError>(cached);
     }
 
@@ -180,14 +183,18 @@ async fn well_known(iii: &III) -> Result<Value, IIIError> {
         default_output_modes: vec!["text".into()],
     };
 
-    Ok::<Value, IIIError>(serde_json::to_value(&card).unwrap())
+    let value = serde_json::to_value(&card).map_err(|e| IIIError::Handler(e.to_string()))?;
+    state_set(iii, "a2a_cards", "orchestrator", value.clone()).await?;
+    Ok::<Value, IIIError>(value)
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let ws_url = std::env::var("III_ENGINE_URL")
+        .or_else(|_| std::env::var("III_WS_URL"))
+        .unwrap_or_else(|_| "ws://localhost:49134".to_string());
     let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();

--- a/workers/a2a-cards/src/types.rs
+++ b/workers/a2a-cards/src/types.rs
@@ -70,6 +70,7 @@ mod tests {
         let val = serde_json::to_value(&card).unwrap();
         assert_eq!(val["capabilities"]["pushNotifications"], json!(false));
         assert_eq!(val["defaultInputModes"], json!(["text"]));
+        assert_eq!(val["defaultOutputModes"], json!(["text"]));
         let back: A2aAgentCard = serde_json::from_value(val).unwrap();
         assert_eq!(back.name, "agentos");
         assert_eq!(back.capabilities.tools, vec!["tool::a"]);

--- a/workers/a2a/src/main.rs
+++ b/workers/a2a/src/main.rs
@@ -1,6 +1,7 @@
 use iii_sdk::error::IIIError;
 use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
 use serde_json::{Value, json};
+use std::net::IpAddr;
 use std::time::Duration;
 
 mod types;
@@ -16,20 +17,22 @@ const VERSION: &str = "0.0.1";
 fn http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
-async fn state_get(iii: &III, scope: &str, key: &str) -> Option<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::get".to_string(),
-        payload: json!({ "scope": scope, "key": key }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .filter(|v| !v.is_null())
+async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {
+    let v = iii
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": scope, "key": key }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(if v.is_null() { None } else { Some(v) })
 }
 
 async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<(), IIIError> {
@@ -56,35 +59,81 @@ async fn state_delete(iii: &III, scope: &str, key: &str) -> Result<(), IIIError>
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
-async fn get_task_order(iii: &III) -> Vec<String> {
-    state_get(iii, "a2a_tasks", "_order")
-        .await
+async fn get_task_order(iii: &III) -> Result<Vec<String>, IIIError> {
+    Ok(state_get(iii, "a2a_tasks", "_order")
+        .await?
         .and_then(|v| v.as_array().cloned())
         .map(|arr| {
             arr.into_iter()
                 .filter_map(|v| v.as_str().map(String::from))
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default())
 }
 
-async fn set_task_order(iii: &III, order: &[String]) -> Result<(), IIIError> {
-    state_set(iii, "a2a_tasks", "_order", json!(order)).await
+/// Atomically append a task id to the `_order` index using `state::update`.
+/// Falls back to read-modify-write if the engine rejects the operation.
+async fn append_task_to_order(iii: &III, task_id: &str) -> Result<(), IIIError> {
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "state::update".to_string(),
+            payload: json!({
+                "scope": "a2a_tasks",
+                "key": "_order",
+                "operations": [
+                    { "type": "append", "path": "", "value": task_id },
+                ],
+            }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await;
+    match result {
+        Ok(_) => Ok(()),
+        Err(_) => {
+            let mut order = get_task_order(iii).await?;
+            order.push(task_id.to_string());
+            state_set(iii, "a2a_tasks", "_order", json!(order)).await
+        }
+    }
 }
 
 async fn evict_old_tasks(iii: &III) -> Result<(), IIIError> {
-    let mut order = get_task_order(iii).await;
+    let mut order = get_task_order(iii).await?;
     while order.len() >= MAX_TASKS {
         let oldest = order.remove(0);
         state_set(iii, "a2a_tasks", &oldest, Value::Null).await?;
     }
-    set_task_order(iii, &order).await
+    state_set(iii, "a2a_tasks", "_order", json!(order)).await
 }
 
-async fn append_task_to_order(iii: &III, task_id: &str) -> Result<(), IIIError> {
-    let mut order = get_task_order(iii).await;
-    order.push(task_id.to_string());
-    set_task_order(iii, &order).await
+fn is_blocked_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || v4.is_documentation()
+                || o[0] == 0
+                || (o[0] == 100 && (64..=127).contains(&o[1]))
+                || o[0] >= 224
+        }
+        IpAddr::V6(v6) => {
+            let seg = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (seg[0] & 0xffc0) == 0xfe80
+                || (seg[0] & 0xfe00) == 0xfc00
+                || seg[0] == 0xff00
+                || (seg[0] == 0x2001 && seg[1] == 0xdb8)
+                || v6.to_ipv4_mapped()
+                    .map(|v4| is_blocked_ip(&IpAddr::V4(v4)))
+                    .unwrap_or(false)
+        }
+    }
 }
 
 fn ssrf_check(url: &str) -> Result<(), IIIError> {
@@ -95,11 +144,24 @@ fn ssrf_check(url: &str) -> Result<(), IIIError> {
             parsed.scheme()
         )));
     }
-    if let Some(host) = parsed.host_str() {
-        let lower = host.to_lowercase();
-        if lower == "metadata.google.internal" || lower == "169.254.169.254" {
-            return Err(IIIError::Handler("blocked metadata host".into()));
-        }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| IIIError::Handler("blocked: missing host".into()))?;
+    let lower = host.to_lowercase();
+
+    if lower == "localhost"
+        || lower.ends_with(".localhost")
+        || lower.ends_with(".local")
+        || lower == "metadata.google.internal"
+        || lower == "metadata"
+    {
+        return Err(IIIError::Handler("blocked host".into()));
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && is_blocked_ip(&ip)
+    {
+        return Err(IIIError::Handler("blocked private IP".into()));
     }
     Ok(())
 }
@@ -120,6 +182,7 @@ async fn rpc_call(
     });
     let client = reqwest::Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| IIIError::Handler(e.to_string()))?;
     let resp = client
@@ -176,8 +239,9 @@ async fn agent_card(iii: &III, input: Value) -> Result<Value, IIIError> {
                 timeout_ms: None,
             })
             .await
-            .ok()
-            .and_then(|v| v.as_array().cloned())
+            .map_err(|e| IIIError::Handler(e.to_string()))?
+            .as_array()
+            .cloned()
             .unwrap_or_default();
         listed
             .into_iter()
@@ -341,6 +405,12 @@ async fn get_task(iii: &III, input: Value) -> Result<Value, IIIError> {
     let agent_url = input
         .get("agentUrl")
         .and_then(|v| v.as_str())
+        .or_else(|| {
+            input
+                .get("query")
+                .and_then(|q| q.get("agentUrl"))
+                .and_then(|v| v.as_str())
+        })
         .map(String::from);
 
     if let Some(url) = agent_url {
@@ -348,7 +418,7 @@ async fn get_task(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     state_get(iii, "a2a_tasks", &task_id)
-        .await
+        .await?
         .ok_or_else(|| IIIError::Handler(format!("Task not found: {task_id}")))
 }
 
@@ -369,7 +439,7 @@ async fn cancel_task(iii: &III, input: Value) -> Result<Value, IIIError> {
     }
 
     let task_val = state_get(iii, "a2a_tasks", &task_id)
-        .await
+        .await?
         .ok_or_else(|| IIIError::Handler(format!("Task not found: {task_id}")))?;
     let mut task: A2aTask =
         serde_json::from_value(task_val).map_err(|e| IIIError::Handler(e.to_string()))?;
@@ -521,7 +591,7 @@ async fn handle_task(iii: &III, input: Value) -> Result<Value, IIIError> {
         }
         "tasks/get" => {
             let task_id = params.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            match state_get(iii, "a2a_tasks", &task_id).await {
+            match state_get(iii, "a2a_tasks", &task_id).await? {
                 Some(task) => Ok::<Value, IIIError>(json!({
                     "jsonrpc": "2.0",
                     "id": rpc_id,
@@ -536,10 +606,23 @@ async fn handle_task(iii: &III, input: Value) -> Result<Value, IIIError> {
         }
         "tasks/cancel" => {
             let task_id = params.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            match state_get(iii, "a2a_tasks", &task_id).await {
+            match state_get(iii, "a2a_tasks", &task_id).await? {
                 Some(task_val) => {
                     let mut task: A2aTask = serde_json::from_value(task_val)
                         .map_err(|e| IIIError::Handler(e.to_string()))?;
+                    if matches!(task.status.state, TaskState::Completed | TaskState::Failed) {
+                        return Ok::<Value, IIIError>(json!({
+                            "jsonrpc": "2.0",
+                            "id": rpc_id,
+                            "error": {
+                                "code": -32002,
+                                "message": format!(
+                                    "Cannot cancel task in state: {:?}",
+                                    task.status.state
+                                ),
+                            },
+                        }));
+                    }
                     task.status = TaskStatus {
                         state: TaskState::Cancelled,
                         message: None,
@@ -582,6 +665,7 @@ async fn discover(iii: &III, input: Value) -> Result<Value, IIIError> {
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| IIIError::Handler(e.to_string()))?;
     let resp = client
@@ -630,7 +714,9 @@ async fn discover(iii: &III, input: Value) -> Result<Value, IIIError> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let ws_url = std::env::var("III_ENGINE_URL")
+        .or_else(|_| std::env::var("III_WS_URL"))
+        .unwrap_or_else(|_| "ws://localhost:49134".to_string());
     let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();

--- a/workers/coordination/src/main.rs
+++ b/workers/coordination/src/main.rs
@@ -31,16 +31,17 @@ fn fire_and_forget(iii: &III, function_id: &str, payload: Value) {
     });
 }
 
-async fn state_get(iii: &III, scope: &str, key: &str) -> Option<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::get".to_string(),
-        payload: json!({ "scope": scope, "key": key }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .filter(|v| !v.is_null())
+async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {
+    let v = iii
+        .trigger(TriggerRequest {
+            function_id: "state::get".to_string(),
+            payload: json!({ "scope": scope, "key": key }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(if v.is_null() { None } else { Some(v) })
 }
 
 async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<(), IIIError> {
@@ -55,21 +56,47 @@ async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<()
     .map_err(|e| IIIError::Handler(e.to_string()))
 }
 
-async fn state_list(iii: &III, scope: &str) -> Vec<Value> {
-    iii.trigger(TriggerRequest {
-        function_id: "state::list".to_string(),
-        payload: json!({ "scope": scope }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .and_then(|v| v.as_array().cloned())
-    .unwrap_or_default()
+async fn state_list(iii: &III, scope: &str) -> Result<Vec<Value>, IIIError> {
+    let v = iii
+        .trigger(TriggerRequest {
+            function_id: "state::list".to_string(),
+            payload: json!({ "scope": scope }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .map_err(|e| IIIError::Handler(e.to_string()))?;
+    Ok(v.as_array().cloned().unwrap_or_default())
 }
 
 fn entry_value(entry: &Value) -> Value {
     entry.get("value").cloned().unwrap_or_else(|| entry.clone())
+}
+
+/// Shared per-channel quota check used by both `post` and `reply`.
+///
+/// TODO: this is a non-atomic check-then-write; concurrent callers can race
+/// past the limit. The engine does not yet expose a counter primitive that
+/// would let us increment-and-check atomically across `state::list`-backed
+/// scopes, so we accept eventual-consistency soft enforcement here.
+async fn ensure_within_post_limit(iii: &III, posts_scope: &str) -> Result<(), IIIError> {
+    let existing = state_list(iii, posts_scope).await?;
+    if existing.len() >= MAX_POSTS_PER_CHANNEL {
+        return Err(IIIError::Handler(
+            "Channel has reached the post limit".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn merge_path_into_request(mut body: Value, input: &Value) -> Value {
+    if let (Some(path), Some(obj)) = (input.get("path"), body.as_object_mut())
+        && let Some(channel_id) = path.get("channelId").and_then(|v| v.as_str())
+    {
+        obj.entry("channelId".to_string())
+            .or_insert_with(|| Value::String(channel_id.to_string()));
+    }
+    body
 }
 
 async fn create_channel(iii: &III, req: CreateChannelRequest) -> Result<Value, IIIError> {
@@ -129,17 +156,12 @@ async fn post(iii: &III, req: PostRequest) -> Result<Value, IIIError> {
 
     let safe_channel_id = sanitize_id(&channel_id).map_err(IIIError::Handler)?;
 
-    if state_get(iii, "coord_channels", &safe_channel_id).await.is_none() {
+    if state_get(iii, "coord_channels", &safe_channel_id).await?.is_none() {
         return Err(IIIError::Handler("Channel not found".into()));
     }
 
     let posts_scope = format!("coord_posts:{safe_channel_id}");
-    let existing = state_list(iii, &posts_scope).await;
-    if existing.len() >= MAX_POSTS_PER_CHANNEL {
-        return Err(IIIError::Handler(
-            "Channel has reached the post limit".into(),
-        ));
-    }
+    ensure_within_post_limit(iii, &posts_scope).await?;
 
     let post_id = uuid::Uuid::new_v4().to_string();
     let safe_agent = sanitize_id(&agent_id).map_err(IIIError::Handler)?;
@@ -190,7 +212,9 @@ async fn reply(iii: &III, req: ReplyRequest) -> Result<Value, IIIError> {
     let safe_agent = sanitize_id(&agent_id).map_err(IIIError::Handler)?;
 
     let posts_scope = format!("coord_posts:{safe_channel_id}");
-    if state_get(iii, &posts_scope, &safe_parent_id).await.is_none() {
+    ensure_within_post_limit(iii, &posts_scope).await?;
+
+    if state_get(iii, &posts_scope, &safe_parent_id).await?.is_none() {
         return Err(IIIError::Handler("Parent post not found".into()));
     }
 
@@ -230,7 +254,7 @@ async fn reply(iii: &III, req: ReplyRequest) -> Result<Value, IIIError> {
 }
 
 async fn list_channels(iii: &III) -> Result<Value, IIIError> {
-    let raw = state_list(iii, "coord_channels").await;
+    let raw = state_list(iii, "coord_channels").await?;
     let mut channels: Vec<Value> = raw.iter().map(entry_value).collect();
     channels.sort_by(|a, b| {
         let ta = a.get("createdAt").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -248,7 +272,7 @@ async fn read(iii: &III, req: ReadRequest) -> Result<Value, IIIError> {
     let safe_channel_id = sanitize_id(&channel_id).map_err(IIIError::Handler)?;
 
     let posts_scope = format!("coord_posts:{safe_channel_id}");
-    let raw = state_list(iii, &posts_scope).await;
+    let raw = state_list(iii, &posts_scope).await?;
 
     let mut posts: Vec<Value> = raw.iter().map(entry_value).collect();
     posts.sort_by(|a, b| {
@@ -289,13 +313,13 @@ async fn pin(iii: &III, req: PinRequest) -> Result<Value, IIIError> {
     let safe_post_id = sanitize_id(&post_id).map_err(IIIError::Handler)?;
 
     let channel_val = state_get(iii, "coord_channels", &safe_channel_id)
-        .await
+        .await?
         .ok_or_else(|| IIIError::Handler("Channel not found".into()))?;
     let mut channel: Channel =
         serde_json::from_value(channel_val).map_err(|e| IIIError::Handler(e.to_string()))?;
 
     let posts_scope = format!("coord_posts:{safe_channel_id}");
-    if state_get(iii, &posts_scope, &safe_post_id).await.is_none() {
+    if state_get(iii, &posts_scope, &safe_post_id).await?.is_none() {
         return Err(IIIError::Handler("Post not found".into()));
     }
 
@@ -329,7 +353,9 @@ async fn pin(iii: &III, req: PinRequest) -> Result<Value, IIIError> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let ws_url = std::env::var("III_WS_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+    let ws_url = std::env::var("III_ENGINE_URL")
+        .or_else(|_| std::env::var("III_WS_URL"))
+        .unwrap_or_else(|_| "ws://localhost:49134".to_string());
     let iii = register_worker(&ws_url, InitOptions::default());
 
     let iii_clone = iii.clone();
@@ -337,7 +363,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RegisterFunction::new_async("coord::create_channel", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
-                let body = input.get("body").cloned().unwrap_or(input);
+                let body = input.get("body").cloned().unwrap_or_else(|| input.clone());
                 let req: CreateChannelRequest =
                     serde_json::from_value(body).map_err(|e| IIIError::Handler(e.to_string()))?;
                 create_channel(&iii, req).await
@@ -351,7 +377,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RegisterFunction::new_async("coord::post", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
-                let body = input.get("body").cloned().unwrap_or(input);
+                let body = input.get("body").cloned().unwrap_or_else(|| input.clone());
+                let body = merge_path_into_request(body, &input);
                 let req: PostRequest =
                     serde_json::from_value(body).map_err(|e| IIIError::Handler(e.to_string()))?;
                 post(&iii, req).await
@@ -365,7 +392,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RegisterFunction::new_async("coord::reply", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
-                let body = input.get("body").cloned().unwrap_or(input);
+                let body = input.get("body").cloned().unwrap_or_else(|| input.clone());
+                let body = merge_path_into_request(body, &input);
                 let req: ReplyRequest =
                     serde_json::from_value(body).map_err(|e| IIIError::Handler(e.to_string()))?;
                 reply(&iii, req).await
@@ -392,7 +420,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .get("body")
                     .cloned()
                     .or_else(|| input.get("query").cloned())
-                    .unwrap_or(input);
+                    .unwrap_or_else(|| input.clone());
+                let body = merge_path_into_request(body, &input);
                 let req: ReadRequest =
                     serde_json::from_value(body).map_err(|e| IIIError::Handler(e.to_string()))?;
                 read(&iii, req).await
@@ -406,7 +435,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RegisterFunction::new_async("coord::pin", move |input: Value| {
             let iii = iii_clone.clone();
             async move {
-                let body = input.get("body").cloned().unwrap_or(input);
+                let body = input.get("body").cloned().unwrap_or_else(|| input.clone());
+                let body = merge_path_into_request(body, &input);
                 let req: PinRequest =
                     serde_json::from_value(body).map_err(|e| IIIError::Handler(e.to_string()))?;
                 pin(&iii, req).await

--- a/workers/coordination/src/types.rs
+++ b/workers/coordination/src/types.rs
@@ -25,8 +25,12 @@ pub struct Post {
     pub parent_id: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: i64,
-    #[serde(default)]
+    #[serde(default = "default_metadata")]
     pub metadata: serde_json::Value,
+}
+
+fn default_metadata() -> serde_json::Value {
+    serde_json::json!({})
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,10 +83,10 @@ pub struct PinRequest {
 
 pub fn sanitize_id(id: &str) -> Result<String, String> {
     if id.is_empty() || id.len() > 256 {
-        return Err(format!("Invalid ID format: {id}"));
+        return Err("Invalid ID format".to_string());
     }
     if !id.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '.')) {
-        return Err(format!("Invalid ID format: {id}"));
+        return Err("Invalid ID format".to_string());
     }
     Ok(id.to_string())
 }

--- a/workers/swarm/src/main.rs
+++ b/workers/swarm/src/main.rs
@@ -90,6 +90,12 @@ async fn create_swarm(iii: &III, req: CreateSwarmRequest) -> Result<Value, IIIEr
         )));
     }
 
+    let agent_ids: Vec<String> = agent_ids
+        .into_iter()
+        .map(|id| sanitize_id(&id))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(IIIError::Handler)?;
+
     let swarm_id = uuid::Uuid::new_v4().to_string();
     let swarm = SwarmConfig {
         id: swarm_id.clone(),
@@ -250,19 +256,17 @@ async fn consensus(iii: &III, req: ConsensusRequest) -> Result<Value, IIIError> 
     let scope = format!("swarm_messages:{safe_swarm_id}");
     let raw = state_list(iii, &scope).await;
 
-    let needle = &req.proposal[..req.proposal.len().min(50)];
-
     let votes: Vec<SwarmMessage> = raw
         .iter()
         .filter_map(|v| serde_json::from_value::<SwarmMessage>(message_value(v)).ok())
-        .filter(|m| m.kind == MessageType::Vote && m.message.contains(needle))
+        .filter(|m| m.kind == MessageType::Vote && m.message == req.proposal)
         .collect();
 
     let mut latest: std::collections::HashMap<String, SwarmMessage> =
         std::collections::HashMap::new();
     for v in votes {
         let entry = latest.get(&v.agent_id);
-        if entry.map_or(true, |e| v.timestamp > e.timestamp) {
+        if entry.is_none_or(|e| v.timestamp > e.timestamp) {
             latest.insert(v.agent_id.clone(), v);
         }
     }
@@ -312,21 +316,21 @@ async fn dissolve(iii: &III, req: DissolveRequest) -> Result<Value, IIIError> {
 
     if let Some(agents_obj) = findings.get("agents").and_then(|v| v.as_object()) {
         for agent_id in &swarm.agent_ids {
-            if let Some(agent_findings) = agents_obj.get(agent_id).and_then(|v| v.as_array()) {
-                if !agent_findings.is_empty() {
-                    let preview: Vec<&Value> = agent_findings.iter().take(10).collect();
-                    let summary = serde_json::to_string(&preview).unwrap_or_else(|_| "[]".into());
-                    fire_and_forget(
-                        iii,
-                        "memory::store",
-                        json!({
-                            "agentId": agent_id,
-                            "sessionId": format!("swarm:{safe_swarm_id}"),
-                            "role": "system",
-                            "content": format!("Swarm {safe_swarm_id} findings: {summary}"),
-                        }),
-                    );
-                }
+            if let Some(agent_findings) = agents_obj.get(agent_id).and_then(|v| v.as_array())
+                && !agent_findings.is_empty()
+            {
+                let preview: Vec<&Value> = agent_findings.iter().take(10).collect();
+                let summary = serde_json::to_string(&preview).unwrap_or_else(|_| "[]".into());
+                fire_and_forget(
+                    iii,
+                    "memory::store",
+                    json!({
+                        "agentId": agent_id,
+                        "sessionId": format!("swarm:{safe_swarm_id}"),
+                        "role": "system",
+                        "content": format!("Swarm {safe_swarm_id} findings: {summary}"),
+                    }),
+                );
             }
         }
     }

--- a/workers/swarm/src/types.rs
+++ b/workers/swarm/src/types.rs
@@ -98,10 +98,10 @@ pub struct DissolveRequest {
 
 pub fn sanitize_id(id: &str) -> Result<String, String> {
     if id.is_empty() || id.len() > 256 {
-        return Err(format!("Invalid ID format: {id}"));
+        return Err("Invalid ID format".to_string());
     }
     if !id.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '.')) {
-        return Err(format!("Invalid ID format: {id}"));
+        return Err("Invalid ID format".to_string());
     }
     Ok(id.to_string())
 }


### PR DESCRIPTION
Addresses CodeRabbit findings on merged #47. Constraints: stay in `workers/{a2a,a2a-cards,swarm,coordination}`, no `iii-sdk` bump, no new deps.

## Critical (2)

### a2a
- `workers/a2a/src/main.rs:90` — **fixed**: `ssrf_check` now blocks loopback, RFC1918 private, link-local, CGNAT (`100.64.0.0/10`), multicast, IPv6 ULA (`fc00::/7`) / link-local (`fe80::/10`) / mapped-v4, plus literal hostnames (`localhost`, `*.local`, `metadata*`). Pure-stdlib (`std::net::IpAddr`), no `ipnetwork` dep.
- `workers/a2a/src/main.rs:16,121,583` — **fixed**: `http_client`, the `rpc_call` per-call builder, and the `discover` client all set `redirect(Policy::none())` so a passing `ssrf_check` cannot be bypassed via a 3xx `Location` to `127.0.0.1` or metadata.

## Major (8)

### a2a
- `workers/a2a/src/main.rs:23` — **fixed**: `state_get` returns `Result<Option<Value>, IIIError>`; storage failures no longer collapse to "task not found".
- `workers/a2a/src/main.rs:75-88` — **fixed**: `append_task_to_order` now uses `state::update` with `{type: "append", path: ""}` (atomic in the engine) and falls back to RMW only on engine error. `evict_old_tasks` rebuilds via the new `get_task_order(...) -> Result`.
- `workers/a2a/src/main.rs:341` — **fixed**: `get_task` resolves `agentUrl` from `input.query.agentUrl` as well as the top-level body, matching how `taskId` is resolved.
- `workers/a2a/src/main.rs:537` — **fixed**: the `tasks/cancel` JSON-RPC branch now rejects `Completed`/`Failed` tasks with `-32002`, matching `a2a::cancel_task`'s public-API semantics.

### a2a-cards
- `workers/a2a-cards/src/main.rs:13,37` — **fixed**: `state_get` / `state_list` propagate trigger errors via `Result`. All callers updated.
- `workers/a2a-cards/src/main.rs:190` — **fixed**: bootstrap now reads `III_ENGINE_URL` first (matches `.env.example`), then `III_WS_URL`, then default. Same fallback applied in `a2a` and `coordination` for consistency.

### coordination
- `workers/coordination/src/main.rs:34,58` — **fixed**: `state_get` / `state_list` propagate via `Result`. Storage outages no longer turn into "channel not found" or empty reads, and the post-cap check no longer silently passes when `state::list` fails.
- `workers/coordination/src/main.rs:174-209` — **fixed**: `reply` now calls the shared `ensure_within_post_limit` helper that `post` also uses, so `MAX_POSTS_PER_CHANNEL` actually bounds the channel.
- `workers/coordination/src/main.rs:351-452` — **fixed**: added `merge_path_into_request` which folds `input.path.channelId` into the deserialized request. `coord::post`, `coord::reply`, `coord::read`, `coord::pin` now honor the `:channelId` path segment instead of requiring clients to also send it in the body.

## Minor (8)

### a2a-cards
- `workers/a2a-cards/src/main.rs:161-184` — **fixed**: `well_known` caches the freshly built orchestrator card to `state_set("a2a_cards", "orchestrator", ...)`.
- `workers/a2a-cards/src/types.rs:73` — **fixed**: test asserts `val["defaultOutputModes"]` to catch rename regressions.

### coordination
- `workers/coordination/src/types.rs:29` — **fixed**: `Post.metadata` uses `#[serde(default = "default_metadata")]` returning `json!({})` instead of `null`.
- `workers/coordination/src/types.rs:82,85` — **fixed**: `sanitize_id` returns a static `"Invalid ID format"` instead of reflecting the raw id.

### swarm
- `workers/swarm/src/main.rs:77-91` — **fixed**: `create_swarm` now sanitizes every incoming agent id (mirrors `broadcast`).
- `workers/swarm/src/main.rs:253-259` — **fixed**: consensus filter uses exact `m.message == req.proposal` equality instead of a 50-char prefix substring.
- `workers/swarm/src/types.rs:101,104` — **fixed**: `sanitize_id` returns static `"Invalid ID format"`.

## Deferred (1)

### coordination
- `workers/coordination/src/main.rs:136-142` — **deferred**: TOCTOU on `MAX_POSTS_PER_CHANNEL` is now centralized in `ensure_within_post_limit` with a `TODO` noting that the engine does not yet expose a counter primitive over `state::list`-backed scopes; remains soft eventual-consistency enforcement.

## Verify

- `cargo check --workspace` — clean
- `cargo test --workspace --release` — all 18 tests across the four affected workers pass; full workspace green
- `cargo clippy -p agentos-a2a -p agentos-a2a-cards -p agentos-swarm -p agentos-coordination --all-targets -- -D warnings` — clean (also fixed two pre-existing lints in `workers/swarm/src/main.rs`)

## Counts

19 CodeRabbit findings → **18 fixed**, **1 deferred with TODO**, 0 stale.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced security with expanded SSRF protections that block localhost, private IP ranges, and disable unsafe redirects in outbound connections
- Improved error handling for state operations and HTTP requests to properly propagate failures instead of silently defaulting

**New Features**
- Added support for agent URL query parameters in task retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->