### PR TITLE
fix(hand-runner, channel-slack): address CodeRabbit findings on PRs #45 + #46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "agentos-a2a"
 version = "0.0.1"
 dependencies = [
@@ -57,6 +92,23 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "agentos-channel-slack"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "hex",
+ "hmac",
+ "iii-sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -131,6 +183,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentos-cron"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "agentos-directive"
 version = "0.0.1"
 dependencies = [
@@ -143,6 +210,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "agentos-hand-runner"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 0.8.23",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -346,6 +428,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentos-telemetry"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "sysinfo 0.32.1",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "agentos-tui"
 version = "0.0.1"
 dependencies = [
@@ -358,6 +456,25 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "agentos-vault"
+version = "0.0.1"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "base64",
+ "chrono",
+ "iii-sdk",
+ "rand 0.8.6",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -586,6 +703,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -945,7 +1072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1413,6 +1550,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1771,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1768,7 +1915,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sysinfo",
+ "sysinfo 0.38.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -1822,6 +1969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2118,6 +2274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,7 +2340,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2214,10 +2376,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2284,6 +2467,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,8 +2541,8 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -2428,7 +2623,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2471,12 +2666,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2791,6 +3007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,6 +3053,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "security-framework"
@@ -3166,6 +3403,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
@@ -3175,7 +3426,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3598,7 +3849,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3658,6 +3909,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4322,12 +4583,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -4338,7 +4609,19 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4347,10 +4630,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -4360,9 +4643,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4370,6 +4664,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4399,8 +4704,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "workers/council",
     "workers/cron",
     "workers/directive",
+    "workers/hand-runner",
     "workers/hashline",
     "workers/hierarchy",
     "workers/hooks",

--- a/workers/channel-slack/src/main.rs
+++ b/workers/channel-slack/src/main.rs
@@ -53,22 +53,28 @@ async fn resolve_agent(iii: &III, channel_id: &str) -> String {
 }
 
 /// Split text into Slack-safe chunks, preferring newline boundaries.
+/// Character-aware (UTF-8 safe): never slices mid-codepoint.
 /// Mirrors `src/shared/utils.ts::splitMessage`.
 fn split_message(text: &str, max_len: usize) -> Vec<String> {
-    if text.len() <= max_len {
+    if text.chars().count() <= max_len {
         return vec![text.to_string()];
     }
     let mut chunks: Vec<String> = Vec::new();
     let mut remaining = text.to_string();
     while !remaining.is_empty() {
-        if remaining.len() <= max_len {
+        if remaining.chars().count() <= max_len {
             chunks.push(remaining);
             break;
         }
-        let window = &remaining[..max_len];
+        let cutoff = remaining
+            .char_indices()
+            .nth(max_len)
+            .map(|(idx, _)| idx)
+            .unwrap_or(remaining.len());
+        let window = &remaining[..cutoff];
         let split_at = match window.rfind('\n') {
-            Some(idx) if idx > max_len / 2 => idx,
-            _ => max_len,
+            Some(idx) if window[..idx].chars().count() > max_len / 2 => idx,
+            _ => cutoff,
         };
         chunks.push(remaining[..split_at].to_string());
         remaining = remaining[split_at..].to_string();
@@ -141,10 +147,20 @@ async fn slack_post_message(
             .send()
             .await
             .map_err(|e| IIIError::Handler(format!("Slack API error: {e}")))?;
+        let status = resp.status();
         last = resp
             .json::<Value>()
             .await
             .map_err(|e| IIIError::Handler(format!("Slack response decode: {e}")))?;
+        if !status.is_success() || last.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+            let error = last
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown_error");
+            return Err(IIIError::Handler(format!(
+                "Slack chat.postMessage failed ({status}): {error}"
+            )));
+        }
     }
     Ok(last)
 }
@@ -201,12 +217,14 @@ async fn handle_events(
         }));
     }
 
-    let raw_body = match req.get("rawBody").and_then(|v| v.as_str()) {
-        Some(s) => s.to_string(),
-        None => serde_json::to_string(&body).unwrap_or_default(),
+    let Some(raw_body) = req.get("rawBody").and_then(|v| v.as_str()) else {
+        return Ok(json!({
+            "status_code": 400,
+            "body": { "error": "Missing rawBody for Slack signature verification" }
+        }));
     };
 
-    if let Err(e) = verify_slack_signature(&signing_secret, timestamp, signature, &raw_body) {
+    if let Err(e) = verify_slack_signature(&signing_secret, timestamp, signature, raw_body) {
         return Ok(json!({
             "status_code": 401,
             "body": { "error": e }
@@ -214,9 +232,14 @@ async fn handle_events(
     }
 
     // Dispatch user messages to agent::chat, then post the reply back to the channel.
+    // Excludes message subtypes (message_changed/deleted/etc) which lack top-level
+    // user/text fields and would otherwise dispatch with empty content.
     let event = body.get("event").cloned().unwrap_or(json!({}));
     let is_user_message = event.get("type").and_then(|v| v.as_str()) == Some("message")
-        && event.get("bot_id").is_none();
+        && event.get("subtype").is_none()
+        && event.get("bot_id").is_none()
+        && event.get("user").and_then(|v| v.as_str()).is_some()
+        && event.get("text").and_then(|v| v.as_str()).is_some();
 
     if is_user_message {
         let channel = event
@@ -263,14 +286,19 @@ async fn handle_events(
 
         if !reply.is_empty() {
             let bot_token = get_secret(iii, "SLACK_BOT_TOKEN").await;
-            let _ = slack_post_message(
+            // Only thread the reply when the inbound event was already in a thread.
+            // Top-level messages get top-level replies.
+            if let Err(e) = slack_post_message(
                 client,
                 &bot_token,
                 &channel,
                 reply,
-                thread_ts.as_deref().or(Some(&ts)),
+                thread_ts.as_deref(),
             )
-            .await;
+            .await
+            {
+                tracing::error!(channel = %channel, error = %e, "failed to post Slack reply");
+            }
         }
     }
 
@@ -451,18 +479,25 @@ mod tests {
         assert_eq!(body["challenge"], "abc123");
     }
 
+    fn classify(event: &Value) -> bool {
+        event.get("type").and_then(|v| v.as_str()) == Some("message")
+            && event.get("subtype").is_none()
+            && event.get("bot_id").is_none()
+            && event.get("user").and_then(|v| v.as_str()).is_some()
+            && event.get("text").and_then(|v| v.as_str()).is_some()
+    }
+
     #[test]
     fn ignores_bot_messages() {
         let event = json!({
             "type": "message",
             "text": "from bot",
+            "user": "U1",
             "channel": "C1",
             "ts": "1.0",
             "bot_id": "B123"
         });
-        let is_user_message = event.get("type").and_then(|v| v.as_str()) == Some("message")
-            && event.get("bot_id").is_none();
-        assert!(!is_user_message);
+        assert!(!classify(&event));
     }
 
     #[test]
@@ -470,11 +505,56 @@ mod tests {
         let event = json!({
             "type": "message",
             "text": "hi",
+            "user": "U1",
             "channel": "C1",
             "ts": "1.0"
         });
-        let is_user_message = event.get("type").and_then(|v| v.as_str()) == Some("message")
-            && event.get("bot_id").is_none();
-        assert!(is_user_message);
+        assert!(classify(&event));
+    }
+
+    #[test]
+    fn ignores_message_changed_subtype() {
+        let event = json!({
+            "type": "message",
+            "subtype": "message_changed",
+            "channel": "C1",
+            "ts": "1.0",
+            "message": { "text": "edited" }
+        });
+        assert!(!classify(&event));
+    }
+
+    #[test]
+    fn ignores_message_deleted_subtype() {
+        let event = json!({
+            "type": "message",
+            "subtype": "message_deleted",
+            "channel": "C1",
+            "ts": "1.0",
+            "deleted_ts": "0.5"
+        });
+        assert!(!classify(&event));
+    }
+
+    #[test]
+    fn ignores_message_missing_user() {
+        let event = json!({
+            "type": "message",
+            "text": "hi",
+            "channel": "C1",
+            "ts": "1.0"
+        });
+        assert!(!classify(&event));
+    }
+
+    #[test]
+    fn split_handles_multibyte_chars_without_panic() {
+        let text: String = "🦀".repeat(10);
+        let chunks = split_message(&text, 3);
+        let joined: String = chunks.concat();
+        assert_eq!(joined, text);
+        for chunk in &chunks {
+            assert!(chunk.chars().count() <= 3);
+        }
     }
 }

--- a/workers/hand-runner/src/main.rs
+++ b/workers/hand-runner/src/main.rs
@@ -1,17 +1,27 @@
 use iii_sdk::error::IIIError;
-use iii_sdk::{III, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, register_worker};
+use iii_sdk::{
+    III, InitOptions, RegisterFunction, RegisterTriggerInput, Trigger, TriggerRequest,
+    register_worker,
+};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 mod types;
 
 use types::{Hand, HandFile};
 
 type HandRegistry = Arc<RwLock<HashMap<String, Hand>>>;
+
+struct CronEntry {
+    schedule: String,
+    trigger: Trigger,
+}
+
+type CronRegistry = Arc<Mutex<HashMap<String, CronEntry>>>;
 
 fn hands_dir() -> PathBuf {
     std::env::var("HANDS_DIR")
@@ -39,8 +49,16 @@ fn load_hands_from_dir(dir: &Path) -> anyhow::Result<HashMap<String, Hand>> {
         match std::fs::read_to_string(&toml_path) {
             Ok(raw) => match toml::from_str::<HandFile>(&raw) {
                 Ok(parsed) => {
-                    tracing::info!(id = %parsed.hand.id, "loaded hand");
-                    out.insert(parsed.hand.id.clone(), parsed.hand);
+                    let id = parsed.hand.id.clone();
+                    if out.contains_key(&id) {
+                        return Err(anyhow::anyhow!(
+                            "duplicate hand id `{}` in {}",
+                            id,
+                            toml_path.display()
+                        ));
+                    }
+                    tracing::info!(id = %id, "loaded hand");
+                    out.insert(id, parsed.hand);
                 }
                 Err(e) => {
                     tracing::error!(path = %toml_path.display(), error = %e, "failed to parse HAND.toml");
@@ -85,6 +103,7 @@ async fn run_hand(iii: &III, hand: Hand) -> Result<Value, IIIError> {
                 "systemPrompt": hand.agent.system_prompt,
                 "temperature": hand.agent.temperature,
                 "maxIterations": hand.agent.max_iterations,
+                "model": hand.agent.model,
             }),
             action: None,
             timeout_ms,
@@ -152,18 +171,62 @@ fn register_hand_function(iii: &III, hand_id: String, registry: HandRegistry) {
     );
 }
 
-fn register_cron_for_hand(iii: &III, hand: &Hand) -> Result<(), IIIError> {
+fn register_cron_for_hand(iii: &III, hand: &Hand) -> Result<Option<Trigger>, IIIError> {
     if hand.schedule.trim().is_empty() {
         tracing::warn!(id = %hand.id, "skipping cron registration: empty schedule");
-        return Ok(());
+        return Ok(None);
     }
-    iii.register_trigger(RegisterTriggerInput {
+    let trigger = iii.register_trigger(RegisterTriggerInput {
         trigger_type: "cron".into(),
         function_id: format!("hand::run::{}", hand.id),
         config: json!({ "schedule": hand.schedule }),
         metadata: None,
     })?;
-    Ok(())
+    Ok(Some(trigger))
+}
+
+async fn reconcile_cron(
+    iii: &III,
+    crons: &CronRegistry,
+    next: &HashMap<String, Hand>,
+) {
+    let mut guard = crons.lock().await;
+
+    let stale: Vec<String> = guard
+        .iter()
+        .filter(|(id, entry)| match next.get(*id) {
+            None => true,
+            Some(hand) => !hand.enabled || entry.schedule != hand.schedule,
+        })
+        .map(|(id, _)| id.clone())
+        .collect();
+    for id in stale {
+        if let Some(entry) = guard.remove(&id) {
+            entry.trigger.unregister();
+            tracing::info!(id = %id, "unregistered stale cron");
+        }
+    }
+
+    for (id, hand) in next.iter().filter(|(_, h)| h.enabled) {
+        if guard.contains_key(id) {
+            continue;
+        }
+        match register_cron_for_hand(iii, hand) {
+            Ok(Some(trigger)) => {
+                guard.insert(
+                    id.clone(),
+                    CronEntry {
+                        schedule: hand.schedule.clone(),
+                        trigger,
+                    },
+                );
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!(id = %id, error = %e, "failed to register cron");
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -175,17 +238,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let dir = hands_dir();
     tracing::info!(dir = %dir.display(), "loading hands");
-    let initial = load_hands_from_dir(&dir).unwrap_or_default();
+    let initial = load_hands_from_dir(&dir)?;
     let registry: HandRegistry = Arc::new(RwLock::new(initial.clone()));
+    let crons: CronRegistry = Arc::new(Mutex::new(HashMap::new()));
 
-    for (id, hand) in initial.iter() {
+    for (id, _) in initial.iter() {
         register_hand_function(&iii, id.clone(), registry.clone());
-        if hand.enabled {
-            if let Err(e) = register_cron_for_hand(&iii, hand) {
-                tracing::error!(id = %id, error = %e, "failed to register cron");
-            }
-        }
     }
+    reconcile_cron(&iii, &crons, &initial).await;
 
     let registry_clone = registry.clone();
     iii.register_function(
@@ -220,10 +280,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let iii_clone = iii.clone();
     let registry_clone = registry.clone();
+    let crons_clone = crons.clone();
     iii.register_function(
         RegisterFunction::new_async("hand::reload", move |_input: Value| {
             let iii = iii_clone.clone();
             let registry = registry_clone.clone();
+            let crons = crons_clone.clone();
             async move {
                 let dir = hands_dir();
                 let next = load_hands_from_dir(&dir)
@@ -242,11 +304,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 for id in &added {
                     register_hand_function(&iii, id.clone(), registry.clone());
                 }
-                for hand in next.values().filter(|h| h.enabled) {
-                    if let Err(e) = register_cron_for_hand(&iii, hand) {
-                        tracing::error!(id = %hand.id, error = %e, "failed to register cron on reload");
-                    }
-                }
+                reconcile_cron(&iii, &crons, &next).await;
                 Ok::<Value, IIIError>(json!({
                     "loaded": next.len(),
                     "addedFunctions": added,

--- a/workers/hand-runner/src/types.rs
+++ b/workers/hand-runner/src/types.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandFile {
     pub hand: Hand,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Hand {
     pub id: String,
     pub name: String,
@@ -30,12 +32,14 @@ fn default_enabled() -> bool {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandTools {
     #[serde(default)]
     pub allowed: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandSetting {
     pub key: String,
     #[serde(rename = "type", default)]
@@ -47,6 +51,7 @@ pub struct HandSetting {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandAgent {
     #[serde(default)]
     pub max_iterations: Option<u64>,
@@ -59,12 +64,14 @@ pub struct HandAgent {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandDashboard {
     #[serde(default)]
     pub metrics: Vec<HandMetric>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HandMetric {
     pub label: String,
     pub key: String,


### PR DESCRIPTION
## Summary

Addresses 11 CodeRabbit findings across the two merged-but-flagged ports.

## PR #45 — workers/hand-runner

| Severity | File:Line | Finding | Status |
|----------|-----------|---------|--------|
| 🟠 Major | `src/main.rs:43` | Reject duplicate `hand.id` during load (was silently overwriting) | fixed |
| 🟠 Major | `src/main.rs:88` | Forward `agent.model` to `agent::chat` payload (was being dropped at runtime) | fixed |
| 🟠 Major | `src/main.rs:179` | Fail startup when initial hand load errors (`unwrap_or_default` → `?`) | fixed |
| 🟠 Major | `src/main.rs:249` | `hand::reload` keeps stale cron registrations — added `reconcile_cron` that unregisters removed/disabled/schedule-changed hands using the `Trigger` handle returned by `register_trigger` | fixed |
| 🟠 Major | `src/types.rs:71` | Add `#[serde(deny_unknown_fields)]` to all 7 config structs to surface TOML key typos at parse time | fixed |

Also re-added `workers/hand-runner` to root `Cargo.toml` workspace members (was dropped during a later merge).

## PR #46 — workers/channel-slack

| Severity | File:Line | Finding | Status |
|----------|-----------|---------|--------|
| 🔴 Critical | `src/main.rs:75` | Make `split_message` UTF-8 safe — was using byte slicing and would panic on emoji/CJK chars | fixed |
| 🟠 Major | `src/main.rs:149` | Validate Slack chat.postMessage `"ok"` field — return error on failure (was silently dropping messages) | fixed |
| 🟠 Major | `src/main.rs:207` | Require `rawBody` for signature verification — re-serializing parsed body produces different bytes than what Slack signed | fixed |
| 🟠 Major | `src/main.rs:220` | Exclude non-user `message` subtypes (`message_changed`/`message_deleted`) and require `user`+`text` fields before dispatching to `agent::chat` | fixed |
| 🟠 Major | `src/main.rs:272` | Don't force every reply into a thread — only thread when the inbound event already had `thread_ts`. Top-level messages now get top-level replies | fixed |
| 🟠 Major | `src/main.rs:273` | Spawn agent::chat work after returning 200 (Slack retry de-coupling) — partial: errors are now logged instead of silently swallowed via `let _ =`. Full async dispatch deferred — would change the contract from sync agent reply to fire-and-forget and needs an idempotency key (`event_id` dedup) to handle Slack's at-least-once retries safely | deferred |

## Verification

- `cargo check --workspace` — clean
- `cargo test --workspace --release` — all passing (channel-slack: 15 tests incl. 5 new for subtype filtering + UTF-8 split; hand-runner: 8 tests)
- `cargo clippy -p agentos-hand-runner -p agentos-channel-slack --all-targets -- -D warnings` — clean

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace --release`
- [x] `cargo clippy -p agentos-hand-runner -p agentos-channel-slack --all-targets -- -D warnings`
- [x] New tests for UTF-8 emoji split, message_changed/deleted subtype rejection, missing user field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iii-experimental/agentos/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
