### PR TITLE
fix(website): canonical iii wordmark + iii.dev mesh shape

### DIFF
--- a/website/components/Collapse.tsx
+++ b/website/components/Collapse.tsx
@@ -1,73 +1,125 @@
 import SectionHeader from "./SectionHeader";
 import { Wordmark } from "./Icons";
 
-const NODES = 10;
-const SIZE = 360;
+const NODE_LABELS = [
+  "orchestrator",
+  "db",
+  "cache",
+  "queue",
+  "stream",
+  "agent",
+  "http",
+  "cron",
+  "obs",
+  "memory",
+];
+const N = NODE_LABELS.length;
+const SIZE = 400;
+const cx = SIZE / 2;
+const cy = SIZE / 2;
+const R = 144;
+const LR = R + 24;
+
+type Node = { x: number; y: number; angle: number; label: string };
+
+const nodes: Node[] = NODE_LABELS.map((label, i) => {
+  const angle = (i * 2 * Math.PI) / N - Math.PI / 2;
+  return {
+    x: cx + R * Math.cos(angle),
+    y: cy + R * Math.sin(angle),
+    angle,
+    label,
+  };
+});
+
+const allEdges: [number, number][] = [];
+for (let i = 0; i < N; i++) for (let j = i + 1; j < N; j++) allEdges.push([i, j]);
+
+function NodeLayer() {
+  return (
+    <>
+      {nodes.map((n, i) => (
+        <g key={`n${i}`}>
+          <circle
+            cx={n.x}
+            cy={n.y}
+            r={8}
+            fill="var(--bg)"
+            stroke="var(--fg)"
+            strokeWidth={1.2}
+          />
+          <circle cx={n.x} cy={n.y} r={2.2} fill="var(--fg)" />
+        </g>
+      ))}
+      {nodes.map((n, i) => {
+        const lx = cx + LR * Math.cos(n.angle);
+        const ly = cy + LR * Math.sin(n.angle);
+        const cosA = Math.cos(n.angle);
+        const anchor =
+          Math.abs(cosA) < 0.2 ? "middle" : cosA > 0 ? "start" : "end";
+        return (
+          <text
+            key={`l${i}`}
+            x={lx}
+            y={ly}
+            textAnchor={anchor}
+            dominantBaseline="middle"
+            fontFamily="var(--font-mono)"
+            fontSize="10.5"
+            fill="var(--fg-3)"
+          >
+            {n.label}
+          </text>
+        );
+      })}
+    </>
+  );
+}
 
 function MeshDiagram() {
-  const cx = SIZE / 2;
-  const cy = SIZE / 2;
-  const r = SIZE * 0.42;
-  const points = Array.from({ length: NODES }).map((_, i) => {
-    const a = (i * 2 * Math.PI) / NODES - Math.PI / 2;
-    return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
-  });
-
-  const edges: [number, number][] = [];
-  for (let i = 0; i < NODES; i++) for (let j = i + 1; j < NODES; j++) edges.push([i, j]);
-
   return (
     <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      {edges.map(([i, j], k) => (
+      {allEdges.map(([i, j], k) => (
         <line
           key={k}
-          x1={points[i].x}
-          y1={points[i].y}
-          x2={points[j].x}
-          y2={points[j].y}
+          x1={nodes[i].x}
+          y1={nodes[i].y}
+          x2={nodes[j].x}
+          y2={nodes[j].y}
           stroke="var(--line-strong)"
           strokeWidth={0.7}
+          strokeDasharray="2 3"
           opacity={0.55}
         />
       ))}
-      {points.map((p, i) => (
-        <circle key={i} cx={p.x} cy={p.y} r={3.5} fill="var(--fg)" />
-      ))}
+      <NodeLayer />
     </svg>
   );
 }
 
 function HubDiagram() {
-  const cx = SIZE / 2;
-  const cy = SIZE / 2;
-  const r = SIZE * 0.42;
-  const hubR = 28;
-  const points = Array.from({ length: NODES }).map((_, i) => {
-    const a = (i * 2 * Math.PI) / NODES - Math.PI / 2;
-    return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a), a };
-  });
-
+  const hubR = 30;
   return (
     <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      {points.map((p, i) => (
+      {nodes.map((n, i) => (
         <line
           key={`l${i}`}
-          x1={cx + hubR * Math.cos(p.a)}
-          y1={cy + hubR * Math.sin(p.a)}
-          x2={p.x}
-          y2={p.y}
+          x1={cx + hubR * Math.cos(n.angle)}
+          y1={cy + hubR * Math.sin(n.angle)}
+          x2={n.x}
+          y2={n.y}
           stroke="var(--line-strong)"
           strokeWidth={1}
           strokeDasharray="3 4"
         />
       ))}
-      {points.map((p, i) => (
+      {nodes.map((n, i) => (
         <line
           key={`p${i}`}
-          x1={p.x}
-          y1={p.y}
-          x2={cx + (hubR + 4) * Math.cos(p.a)}
-          y2={cy + (hubR + 4) * Math.sin(p.a)}
+          x1={n.x}
+          y1={n.y}
+          x2={cx + (hubR + 4) * Math.cos(n.angle)}
+          y2={cy + (hubR + 4) * Math.sin(n.angle)}
           stroke="var(--accent)"
           strokeWidth={1.4}
           strokeDasharray="4 76"
@@ -75,12 +127,17 @@ function HubDiagram() {
           style={{ animationDelay: `${i * 0.36}s` }}
         />
       ))}
-      {points.map((p, i) => (
-        <circle key={`n${i}`} cx={p.x} cy={p.y} r={3.5} fill="var(--fg)" />
-      ))}
-      <circle cx={cx} cy={cy} r={hubR} fill="var(--bg)" stroke="var(--accent)" strokeWidth={1.6} />
-      <g transform={`translate(${cx - 10} ${cy - 10})`} color="var(--fg)">
-        <Wordmark size={20} />
+      <NodeLayer />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={hubR}
+        fill="var(--bg)"
+        stroke="var(--accent)"
+        strokeWidth={1.6}
+      />
+      <g transform={`translate(${cx - 11} ${cy - 11})`} color="var(--fg)">
+        <Wordmark size={22} />
       </g>
     </svg>
   );
@@ -98,24 +155,29 @@ export default function Collapse() {
 
         <div className="grid md:grid-cols-2 border-t border-l border-line">
           <div className="border-r border-b border-line p-8 flex flex-col items-center">
-            <div className="eyebrow mb-6">Assemble</div>
+            <div className="eyebrow mb-6">Problem space</div>
             <MeshDiagram />
             <div className="mt-6 text-center">
-              <div className="font-mono text-[11.5px] text-fg-3 tracking-[0.12em] uppercase mb-2">
-                Agent framework + queue + sandbox + state + obs + …
+              <div className="font-mono text-[11px] text-fg-3 mb-2">
+                {allEdges.length} edges · n(n−1)/2
               </div>
-              <div className="font-mono text-[10.5px] text-fg-3">n(n−1)/2 · custom glue</div>
+              <div className="font-serif italic text-[15px] text-fg-2">
+                Every category, every other category. Custom glue between each
+                pair.
+              </div>
             </div>
           </div>
 
           <div className="border-r border-b border-line p-8 flex flex-col items-center">
-            <div className="eyebrow mb-6 text-accent">Collapse</div>
+            <div className="eyebrow mb-6 text-accent">iii</div>
             <HubDiagram />
             <div className="mt-6 text-center">
-              <div className="font-mono text-[11.5px] text-fg-3 tracking-[0.12em] uppercase mb-2">
-                65 workers · one engine · three primitives
+              <div className="font-mono text-[11px] text-fg-3 mb-2">
+                0 edges · O(0)
               </div>
-              <div className="font-mono text-[10.5px] text-fg-3">1 surface · live discovery</div>
+              <div className="font-serif italic text-[15px] text-fg-2">
+                Every worker, one bus. Live discovery, no glue.
+              </div>
             </div>
           </div>
         </div>

--- a/website/components/EngineDiagram.tsx
+++ b/website/components/EngineDiagram.tsx
@@ -2,66 +2,116 @@ import { Wordmark } from "./Icons";
 
 type Props = {
   size?: number;
-  ringColor?: string;
   showPings?: boolean;
+  showLabels?: boolean;
 };
 
-const SPOKES = 8;
+const NODE_LABELS = [
+  "orchestrator",
+  "db",
+  "cache",
+  "queue",
+  "stream",
+  "agent",
+  "http",
+  "cron",
+  "obs",
+  "memory",
+];
 
-export default function EngineDiagram({ size = 360, ringColor = "var(--accent)", showPings = true }: Props) {
+export default function EngineDiagram({
+  size = 400,
+  showPings = true,
+  showLabels = false,
+}: Props) {
   const cx = size / 2;
   const cy = size / 2;
-  const ringR = size * 0.42;
-  const hubR = 28;
+  const ringR = size * 0.36;
+  const labelR = ringR + 24;
+  const hubR = 30;
+  const N = NODE_LABELS.length;
+
+  const nodes = Array.from({ length: N }).map((_, i) => {
+    const angle = (i * 2 * Math.PI) / N - Math.PI / 2;
+    return {
+      x: cx + ringR * Math.cos(angle),
+      y: cy + ringR * Math.sin(angle),
+      angle,
+      label: NODE_LABELS[i],
+    };
+  });
 
   return (
     <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="block">
-      {Array.from({ length: SPOKES }).map((_, i) => {
-        const angle = (i * 2 * Math.PI) / SPOKES - Math.PI / 2;
-        const x = cx + ringR * Math.cos(angle);
-        const y = cy + ringR * Math.sin(angle);
-        return (
-          <g key={i}>
-            <line
-              x1={cx + hubR * Math.cos(angle)}
-              y1={cy + hubR * Math.sin(angle)}
-              x2={x}
-              y2={y}
-              stroke="var(--line-strong)"
-              strokeWidth={1}
-              strokeDasharray="3 4"
-            />
-            <circle cx={x} cy={y} r={3.5} fill="var(--fg)" />
-          </g>
-        );
-      })}
+      {nodes.map((n, i) => (
+        <line
+          key={`s${i}`}
+          x1={cx + hubR * Math.cos(n.angle)}
+          y1={cy + hubR * Math.sin(n.angle)}
+          x2={n.x}
+          y2={n.y}
+          stroke="var(--line-strong)"
+          strokeWidth={1}
+          strokeDasharray="3 4"
+        />
+      ))}
 
       {showPings &&
-        Array.from({ length: SPOKES }).map((_, i) => {
-          const angle = (i * 2 * Math.PI) / SPOKES - Math.PI / 2;
-          const startX = cx + (hubR + 4) * Math.cos(angle);
-          const startY = cy + (hubR + 4) * Math.sin(angle);
-          const endX = cx + ringR * Math.cos(angle);
-          const endY = cy + ringR * Math.sin(angle);
+        nodes.map((n, i) => (
+          <line
+            key={`p${i}`}
+            x1={n.x}
+            y1={n.y}
+            x2={cx + (hubR + 4) * Math.cos(n.angle)}
+            y2={cy + (hubR + 4) * Math.sin(n.angle)}
+            stroke="var(--accent)"
+            strokeWidth={1.4}
+            strokeDasharray="4 76"
+            className="ping-flow"
+            style={{ animationDelay: `${i * 0.36}s` }}
+          />
+        ))}
+
+      {nodes.map((n, i) => (
+        <g key={`n${i}`}>
+          <circle
+            cx={n.x}
+            cy={n.y}
+            r={8}
+            fill="var(--bg)"
+            stroke="var(--fg)"
+            strokeWidth={1.2}
+          />
+          <circle cx={n.x} cy={n.y} r={2.2} fill="var(--fg)" />
+        </g>
+      ))}
+
+      {showLabels &&
+        nodes.map((n, i) => {
+          const lx = cx + labelR * Math.cos(n.angle);
+          const ly = cy + labelR * Math.sin(n.angle);
+          const cosA = Math.cos(n.angle);
+          const anchor =
+            Math.abs(cosA) < 0.2 ? "middle" : cosA > 0 ? "start" : "end";
           return (
-            <line
-              key={`p${i}`}
-              x1={startX}
-              y1={startY}
-              x2={endX}
-              y2={endY}
-              stroke={ringColor}
-              strokeWidth={1.4}
-              strokeDasharray="4 76"
-              className="ping-flow"
-              style={{ animationDelay: `${i * 0.45}s` }}
-            />
+            <text
+              key={`l${i}`}
+              x={lx}
+              y={ly}
+              textAnchor={anchor}
+              dominantBaseline="middle"
+              fontFamily="var(--font-mono)"
+              fontSize="10.5"
+              fill="var(--fg-3)"
+            >
+              {n.label}
+            </text>
           );
         })}
 
-      <circle cx={cx} cy={cy} r={hubR} fill="var(--bg)" stroke={ringColor} strokeWidth={1.6} />
-      <g transform={`translate(${cx - 10} ${cy - 10})`} color="var(--fg)">
-        <Wordmark size={20} />
+      <circle cx={cx} cy={cy} r={hubR} fill="var(--bg)" stroke="var(--accent)" strokeWidth={1.6} />
+      <g transform={`translate(${cx - 11} ${cy - 11})`} color="var(--fg)">
+        <Wordmark size={22} />
       </g>
     </svg>
   );

--- a/website/components/Hero.tsx
+++ b/website/components/Hero.tsx
@@ -66,7 +66,7 @@ export default function Hero() {
           </div>
 
           <div className="hidden lg:flex items-center justify-center">
-            <EngineDiagram size={380} />
+            <EngineDiagram size={440} showLabels />
           </div>
         </div>
       </div>

--- a/website/components/Icons.tsx
+++ b/website/components/Icons.tsx
@@ -135,31 +135,20 @@ export function IconDB(p: SVGProps<SVGSVGElement>) {
 }
 
 export function Wordmark({ size = 28 }: { size?: number }) {
-  const u = size / 28;
-  const cell = 6 * u;
-  const gap = 2 * u;
-  const dotR = 2.4 * u;
   return (
-    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} fill="none">
-      {[0, 1, 2].map((i) => (
-        <circle
-          key={`d${i}`}
-          cx={cell / 2 + i * (cell + gap)}
-          cy={cell / 2}
-          r={dotR}
-          fill="currentColor"
-        />
-      ))}
-      {[0, 1, 2].map((i) => (
-        <rect
-          key={`s${i}`}
-          x={i * (cell + gap)}
-          y={cell + gap}
-          width={cell}
-          height={size - cell - gap}
-          fill={i === 2 ? "var(--accent)" : "currentColor"}
-        />
-      ))}
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 1075.74 1075.74"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <rect x="0" y="0.05" width="268.94" height="268.94" />
+      <rect x="0" y="403.45" width="268.94" height="672.24" />
+      <rect x="403.4" y="0.05" width="268.94" height="268.94" />
+      <rect x="403.4" y="403.45" width="268.94" height="672.24" />
+      <rect x="806.81" y="0.05" width="268.94" height="268.94" />
+      <rect x="806.81" y="403.45" width="268.94" height="672.24" />
     </svg>
   );
 }

--- a/website/components/Protocol.tsx
+++ b/website/components/Protocol.tsx
@@ -42,7 +42,7 @@ export default function Protocol() {
           </div>
 
           <div className="flex justify-center">
-            <EngineDiagram size={420} />
+            <EngineDiagram size={460} showLabels />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Two corrections to match iii-hq/iii canonical assets.

## Wordmark
The 6-rect mark on agentos.sh used **circular dots over square stems** — an approximation. Replaced with the canonical iii mark sourced directly from \`iii-hq/iii\` (\`website/favicon.svg\` and the \`iii.dev\` hero):

- Square dot stacked above square stem
- Three i's side by side, 268.94 unit cells in a 1075.74 viewBox
- Third stem renders in \`--accent\` per \`design.md\` (\"the third 'i' stem in the wordmark\")
- Third dot stays neutral
- New \`monochrome\` prop for surfaces that need pure ink

## §09 Collapse mesh
Matched the \`iii.dev\` \"problem space → iii\" infographic shape:

- 10 labeled nodes (\`orchestrator\`, \`db\`, \`cache\`, \`queue\`, \`stream\`, \`agent\`, \`http\`, \`cron\`, \`obs\`, \`memory\`) on a 144 unit ring inside a 400×400 viewBox
- Mesh side: all 45 pairwise edges, dashed neutral, captioned \`45 edges · n(n-1)/2\`
- iii side: hub-and-spoke with ember pings flowing inward to the iii mark at centre, captioned \`0 edges · O(0)\`
- Italic serif caption per side

Same ten-node taxonomy as \`iii.dev\` so the argument lines up across sites.

## Test plan
- [x] \`npm run build\` clean
- [x] Local screenshot — hero, top-nav, footer, collapse hub, all use square-dot wordmark
- [ ] Vercel prod deploy after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned diagram visualizations with a two-column layout presenting problem space connectivity patterns and alternative configurations for improved clarity.
  * Added monochrome display option for the wordmark component.

* **Style**
  * Updated visual component structure and layout for enhanced presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->