### PR TITLE
feat(tui): chat-first refactor with slash commands + worker picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,35 @@ website/         agentsos.sh — design.md aesthetic, three themes
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full primitive flow and worker manifest spec.
 
-## § 09 · Build and test
+## § 09 · TUI
+
+Chat-first terminal UI lives in `crates/tui`:
+
+```bash
+cargo run --release -p agentos-tui
+```
+
+| Key | Action |
+|---|---|
+| `/` | Slash command (`/agent`, `/memory`, `/worker`, `/realm`, `/skill`, `/hand`, `/help`, `/quit`) |
+| `Tab` | Autocomplete current slash command against the live function registry |
+| `?` | Toggle keymap overlay |
+| `Ctrl+P` | Command palette (fuzzy-jump to any pane) |
+| `Ctrl+W` | Worker picker — browse + install workers without leaving the TUI |
+| `Esc` | Close overlay or clear input |
+| `1-9 0` | Direct pane switch (Dashboard / Agents / Chat / Channels / …) |
+
+If the engine is offline or no workers are connected, the TUI shows a first-run overlay with copy-paste commands instead of an empty list. Slash completions pull from `GET /iii/functions` so anything a worker registers is immediately discoverable.
+
+## § 10 · Build and test
 
 ```bash
 cargo build --workspace --release   # all 64 Rust workers
-cargo test --workspace --release    # 1,281 tests
+cargo test --workspace --release    # 1,316 tests
 npm install && npm run test:e2e     # live engine + workers (requires AGENTOS_API_KEY)
 ```
 
-## § 10 · Versioning
+## § 11 · Versioning
 
 | | version |
 |---|---|
@@ -171,6 +191,6 @@ npm install && npm run test:e2e     # live engine + workers (requires AGENTOS_AP
 | iii-sdk (Python) | `>=0.11.6` for the embedding worker |
 | agentos | `0.0.1` — pre-1.0; reserved for behavioral proof against live infra, not feature completeness |
 
-## § 11 · License
+## § 12 · License
 
 Apache-2.0. Same family as `iii-sdk` and the rest of the iii ecosystem.

--- a/assets/banner-dark.svg
+++ b/assets/banner-dark.svg
@@ -4,7 +4,7 @@
 
   <g font-family="JetBrains Mono, ui-monospace, monospace" font-size="11" fill="#8c8780" letter-spacing="1.98">
     <text x="60" y="60">§ 01 · AGENTOS</text>
-    <text x="1140" y="60" text-anchor="end">01 / 11</text>
+    <text x="1140" y="60" text-anchor="end">01 / 12</text>
   </g>
   <line x1="60" y1="74" x2="1140" y2="74" stroke="#f2ede1" stroke-opacity="0.12"/>
 

--- a/assets/banner-light.svg
+++ b/assets/banner-light.svg
@@ -4,7 +4,7 @@
 
   <g font-family="JetBrains Mono, ui-monospace, monospace" font-size="11" fill="#6b6660" letter-spacing="1.98">
     <text x="60" y="60">§ 01 · AGENTOS</text>
-    <text x="1140" y="60" text-anchor="end">01 / 11</text>
+    <text x="1140" y="60" text-anchor="end">01 / 12</text>
   </g>
   <line x1="60" y1="74" x2="1140" y2="74" stroke="#0c0b0a" stroke-opacity="0.12"/>
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -16,5 +16,5 @@ anyhow.workspace = true
 tracing.workspace = true
 ratatui = "0.29"
 crossterm = "0.28"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 futures-util = "0.3"

--- a/crates/tui/src/first_run.rs
+++ b/crates/tui/src/first_run.rs
@@ -1,0 +1,155 @@
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::help_overlay::centered_rect;
+use crate::theme;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HealthState {
+    EngineDown,
+    EngineUpNoWorkers,
+    Ready,
+}
+
+pub fn detect(engine_healthy: bool, worker_count: usize) -> HealthState {
+    if !engine_healthy {
+        HealthState::EngineDown
+    } else if worker_count == 0 {
+        HealthState::EngineUpNoWorkers
+    } else {
+        HealthState::Ready
+    }
+}
+
+pub fn draw_engine_down(f: &mut Frame, area: Rect) {
+    let popup = centered_rect(70, 60, area);
+    f.render_widget(Clear, popup);
+
+    let lines: Vec<Line> = vec![
+        Line::from(Span::styled("AGENTOS · WELCOME", theme::eyebrow())),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "Engine is offline. Boot it in another terminal:",
+            theme::title(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  1.  Install the iii engine binary",
+            theme::dim(),
+        )),
+        Line::from(Span::styled(
+            "      curl -fsSL https://install.iii.dev/iii/main/install.sh | sh",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled("  2.  Set your model key", theme::dim())),
+        Line::from(Span::styled(
+            "      export ANTHROPIC_API_KEY=sk-ant-...",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled("  3.  Start the engine", theme::dim())),
+        Line::from(Span::styled(
+            "      iii --config config.yaml",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled("  4.  Spawn workers", theme::dim())),
+        Line::from(Span::styled(
+            "      bash scripts/dev-up.sh",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  TUI will detect the engine the moment it comes up.",
+            theme::dim(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  Press q to quit · ? for keymap",
+            theme::dim(),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(Span::styled(" First run ", theme::title()));
+
+    f.render_widget(
+        Paragraph::new(lines).block(block).wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+pub fn draw_no_workers(f: &mut Frame, area: Rect) {
+    let popup = centered_rect(70, 50, area);
+    f.render_widget(Clear, popup);
+
+    let lines: Vec<Line> = vec![
+        Line::from(Span::styled("AGENTOS · NO WORKERS", theme::eyebrow())),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "Engine is up, but no workers are connected.",
+            theme::title(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  Spawn the default 65-worker stack:",
+            theme::dim(),
+        )),
+        Line::from(Span::styled(
+            "    bash scripts/dev-up.sh",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  Or browse + install one at a time:",
+            theme::dim(),
+        )),
+        Line::from(Span::styled(
+            "    Press Ctrl+W for the worker picker",
+            theme::accent(),
+        )),
+        Line::raw(""),
+        Line::from(Span::styled(
+            "  Press Esc to dismiss · ? for keymap",
+            theme::dim(),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(Span::styled(" Almost there ", theme::title()));
+
+    f.render_widget(
+        Paragraph::new(lines).block(block).wrap(Wrap { trim: false }),
+        popup,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_engine_down() {
+        assert_eq!(detect(false, 0), HealthState::EngineDown);
+        assert_eq!(detect(false, 99), HealthState::EngineDown);
+    }
+
+    #[test]
+    fn detects_no_workers() {
+        assert_eq!(detect(true, 0), HealthState::EngineUpNoWorkers);
+    }
+
+    #[test]
+    fn detects_ready() {
+        assert_eq!(detect(true, 1), HealthState::Ready);
+    }
+}

--- a/crates/tui/src/help_overlay.rs
+++ b/crates/tui/src/help_overlay.rs
@@ -1,0 +1,86 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::theme;
+
+pub struct KeyBind {
+    pub keys: &'static str,
+    pub action: &'static str,
+}
+
+pub const KEYMAP: &[KeyBind] = &[
+    KeyBind { keys: "/", action: "Slash command (/agent, /memory, /worker, ...)" },
+    KeyBind { keys: "Enter", action: "Send message / confirm action" },
+    KeyBind { keys: "Tab", action: "Autocomplete slash command" },
+    KeyBind { keys: "Ctrl+P", action: "Command palette (jump to any pane)" },
+    KeyBind { keys: "Ctrl+W", action: "Worker picker (browse + install)" },
+    KeyBind { keys: "?", action: "Toggle this help" },
+    KeyBind { keys: "Esc", action: "Close overlay / clear input" },
+    KeyBind { keys: "Ctrl+L", action: "Clear chat scrollback" },
+    KeyBind { keys: "Ctrl+C / q", action: "Quit" },
+    KeyBind { keys: "y / n", action: "Approve / deny pending request (in approval modal)" },
+    KeyBind { keys: "1-9, 0", action: "Switch to numbered pane (Dashboard, Agents, Chat...)" },
+    KeyBind { keys: "j / k", action: "Move down / up in lists (vim)" },
+];
+
+pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
+pub fn draw(f: &mut Frame, area: Rect) {
+    let popup = centered_rect(70, 70, area);
+    f.render_widget(Clear, popup);
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            "AGENTOS · KEYMAP",
+            theme::eyebrow(),
+        )),
+        Line::raw(""),
+    ];
+    for kb in KEYMAP {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {:<14}", kb.keys), theme::accent()),
+            Span::raw(kb.action.to_string()),
+        ]));
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        "  Press Esc or ? to close.",
+        theme::dim(),
+    )));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::EMBER))
+        .title(Span::styled(" Help ", Style::default().add_modifier(Modifier::BOLD)));
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: false }),
+        popup,
+    );
+}

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1,3 +1,13 @@
+mod first_run;
+mod help_overlay;
+mod markdown;
+mod palette;
+mod slash;
+mod sse;
+mod status;
+mod theme;
+mod worker_picker;
+
 use anyhow::Result;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -10,6 +20,8 @@ use ratatui::{
 };
 use serde_json::Value;
 use std::io::stdout;
+
+use crate::palette::PaletteItem;
 
 const API_BASE: &str = "http://localhost:3111";
 const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -178,12 +190,25 @@ struct App {
     approval_mode: bool,
     pending_chord: Option<char>,
     chord_timeout: Option<std::time::Instant>,
+    show_help: bool,
+    show_palette: bool,
+    show_worker_picker: bool,
+    show_first_run: bool,
+    palette_query: String,
+    palette_selected: usize,
+    slash_completions: Vec<(String, String)>,
+    slash_selected: usize,
+    registry_fns: Vec<String>,
+    chat_realm: String,
+    worker_count: usize,
+    worker_catalog: Vec<worker_picker::WorkerCard>,
+    worker_picker_selected: usize,
 }
 
 impl App {
     fn new() -> Self {
         Self {
-            screen: Screen::Dashboard,
+            screen: Screen::Chat,
             selected: 0,
             status: "Connecting...".into(),
             healthy: false,
@@ -231,7 +256,73 @@ impl App {
             approval_mode: false,
             pending_chord: None,
             chord_timeout: None,
+            show_help: false,
+            show_palette: false,
+            show_worker_picker: false,
+            show_first_run: true,
+            palette_query: String::new(),
+            palette_selected: 0,
+            slash_completions: vec![],
+            slash_selected: 0,
+            registry_fns: vec![],
+            chat_realm: "default".into(),
+            worker_count: 0,
+            worker_catalog: vec![],
+            worker_picker_selected: 0,
         }
+    }
+
+    fn refresh_slash_completions(&mut self) {
+        if self.chat_input.starts_with('/') {
+            let body = &self.chat_input[1..];
+            let partial = body.split_whitespace().next().unwrap_or("");
+            self.slash_completions = slash::complete(partial, &self.registry_fns);
+            if self.slash_selected >= self.slash_completions.len() {
+                self.slash_selected = 0;
+            }
+        } else {
+            self.slash_completions.clear();
+            self.slash_selected = 0;
+        }
+    }
+
+    async fn refresh_registry(&mut self) {
+        let client = Self::client();
+        if let Ok(resp) = client.get(format!("{}/iii/functions", API_BASE)).send().await
+            && let Ok(data) = resp.json::<Value>().await
+        {
+            self.registry_fns = slash::extract_function_names(&data);
+        }
+        if let Ok(resp) = client.get(format!("{}/iii/workers", API_BASE)).send().await
+            && let Ok(data) = resp.json::<Value>().await
+        {
+            self.worker_count = data.as_array().map(|a| a.len()).unwrap_or(0);
+        }
+    }
+
+    async fn refresh_worker_catalog(&mut self) {
+        let client = Self::client();
+        if let Ok(resp) = client.get(format!("{}/api/workers/catalog", API_BASE)).send().await
+            && let Ok(data) = resp.json::<Value>().await
+        {
+            let installed: Vec<String> = self
+                .agents
+                .iter()
+                .filter_map(|a| a["worker"].as_str().map(String::from))
+                .collect();
+            self.worker_catalog = worker_picker::parse_catalog(&data, &installed);
+        }
+    }
+
+    fn palette_items(&self) -> Vec<PaletteItem> {
+        Screen::all()
+            .iter()
+            .map(|s| PaletteItem {
+                label: s.label().to_string(),
+                hint: format!("Switch to {}", s.label()),
+                action_key: s.key().to_string(),
+            })
+            .collect()
     }
 
     fn client() -> reqwest::Client {
@@ -506,6 +597,81 @@ impl App {
         }
     }
 
+    async fn handle_slash(&mut self, parsed: slash::Parsed) {
+        let (name, args) = match parsed {
+            slash::Parsed::Cmd { name, args } => (name, args),
+            slash::Parsed::Incomplete { partial } => {
+                self.chat_messages
+                    .push(("system".into(), format!("Incomplete command: /{}", partial)));
+                return;
+            }
+            slash::Parsed::Plain(_) => return,
+        };
+        match name.as_str() {
+            "agent" => {
+                if args.is_empty() {
+                    self.chat_messages.push(("system".into(), format!("agent: {}", self.chat_agent)));
+                } else {
+                    self.chat_agent = args.clone();
+                    self.chat_messages.push(("system".into(), format!("Switched to agent {}", args)));
+                }
+            }
+            "realm" => {
+                self.chat_realm = args.clone();
+                self.chat_messages.push(("system".into(), format!("Realm: {}", args)));
+            }
+            "memory" => {
+                let client = Self::client();
+                let body = serde_json::json!({"namespace": self.chat_realm, "query": args});
+                match client.post(format!("{}/api/memory/recall", API_BASE)).json(&body).send().await {
+                    Ok(resp) => match resp.json::<Value>().await {
+                        Ok(v) => self.chat_messages.push(("assistant".into(), v.to_string())),
+                        Err(e) => self.chat_messages.push(("system".into(), format!("recall parse error: {}", e))),
+                    },
+                    Err(e) => self.chat_messages.push(("system".into(), format!("recall failed: {}", e))),
+                }
+            }
+            "remember" => {
+                let client = Self::client();
+                let body = serde_json::json!({"namespace": self.chat_realm, "content": args});
+                match client.post(format!("{}/api/memory/store", API_BASE)).json(&body).send().await {
+                    Ok(_) => self.chat_messages.push(("system".into(), "stored".into())),
+                    Err(e) => self.chat_messages.push(("system".into(), format!("store failed: {}", e))),
+                }
+            }
+            "hand" => {
+                self.chat_messages.push(("system".into(), format!("Hand invoke not yet wired: {}", args)));
+            }
+            "skill" => {
+                self.chat_messages.push(("system".into(), format!("Skill invoke not yet wired: {}", args)));
+            }
+            "worker" => {
+                self.refresh_worker_catalog().await;
+                self.show_worker_picker = true;
+                self.worker_picker_selected = 0;
+            }
+            "channel" => {
+                self.chat_messages.push(("system".into(), format!("Channel send not yet wired: {}", args)));
+            }
+            "approve" | "deny" => {
+                self.chat_messages.push(("system".into(), format!("{}: {}", name, args)));
+            }
+            "clear" => {
+                self.chat_messages.clear();
+            }
+            "help" => {
+                self.show_help = true;
+            }
+            "quit" => {
+                self.running = false;
+            }
+            other => {
+                self.chat_messages
+                    .push(("system".into(), format!("Unknown command: /{}", other)));
+            }
+        }
+    }
+
     async fn send_chat(&mut self) {
         if self.chat_input.trim().is_empty() {
             return;
@@ -653,6 +819,10 @@ async fn main() -> Result<()> {
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
     let mut app = App::new();
     app.refresh_health().await;
+    app.refresh_registry().await;
+    if first_run::detect(app.healthy, app.worker_count) == first_run::HealthState::Ready {
+        app.show_first_run = false;
+    }
 
     let mut last_health = std::time::Instant::now();
 
@@ -661,6 +831,10 @@ async fn main() -> Result<()> {
 
         if last_health.elapsed() > std::time::Duration::from_secs(10) {
             app.refresh_health().await;
+            app.refresh_registry().await;
+            if first_run::detect(app.healthy, app.worker_count) == first_run::HealthState::Ready {
+                app.show_first_run = false;
+            }
             last_health = std::time::Instant::now();
         }
 
@@ -680,6 +854,113 @@ async fn main() -> Result<()> {
                 && matches!(key.code, KeyCode::Char('c'));
             if ctrl_c {
                 app.running = false;
+                continue;
+            }
+
+            if app.show_help {
+                if matches!(key.code, KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')) {
+                    app.show_help = false;
+                }
+                continue;
+            }
+
+            if app.show_palette {
+                match key.code {
+                    KeyCode::Esc => {
+                        app.show_palette = false;
+                        app.palette_query.clear();
+                        app.palette_selected = 0;
+                    }
+                    KeyCode::Backspace => {
+                        app.palette_query.pop();
+                        app.palette_selected = 0;
+                    }
+                    KeyCode::Up => {
+                        app.palette_selected = app.palette_selected.saturating_sub(1);
+                    }
+                    KeyCode::Down => {
+                        app.palette_selected = app.palette_selected.saturating_add(1);
+                    }
+                    KeyCode::Enter => {
+                        let items = app.palette_items();
+                        let ranked = palette::rank(&items, &app.palette_query);
+                        if let Some((idx, _)) = ranked.get(app.palette_selected) {
+                            let target = items[*idx].action_key.clone();
+                            for s in Screen::all() {
+                                if s.key() == target {
+                                    navigate_to(&mut app, *s);
+                                    app.refresh_screen().await;
+                                    break;
+                                }
+                            }
+                        }
+                        app.show_palette = false;
+                        app.palette_query.clear();
+                        app.palette_selected = 0;
+                    }
+                    KeyCode::Char(c) => {
+                        app.palette_query.push(c);
+                        app.palette_selected = 0;
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            if app.show_worker_picker {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        app.show_worker_picker = false;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        app.worker_picker_selected = app.worker_picker_selected.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if app.worker_picker_selected + 1 < app.worker_catalog.len() {
+                            app.worker_picker_selected += 1;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if let Some(card) = app.worker_catalog.get(app.worker_picker_selected) {
+                            app.status = worker_picker::install_command(card);
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            if app.show_first_run {
+                if matches!(key.code, KeyCode::Esc) {
+                    app.show_first_run = false;
+                } else if matches!(key.code, KeyCode::Char('q')) {
+                    app.running = false;
+                }
+                continue;
+            }
+
+            if matches!(key.code, KeyCode::Char('?'))
+                && !matches!(app.screen, Screen::Chat)
+            {
+                app.show_help = true;
+                continue;
+            }
+
+            let ctrl_p = key.modifiers.contains(KeyModifiers::CONTROL)
+                && matches!(key.code, KeyCode::Char('p'));
+            if ctrl_p {
+                app.show_palette = true;
+                app.palette_query.clear();
+                app.palette_selected = 0;
+                continue;
+            }
+
+            let ctrl_w = key.modifiers.contains(KeyModifiers::CONTROL)
+                && matches!(key.code, KeyCode::Char('w'));
+            if ctrl_w {
+                app.refresh_worker_catalog().await;
+                app.show_worker_picker = true;
+                app.worker_picker_selected = 0;
                 continue;
             }
 
@@ -799,21 +1080,51 @@ async fn main() -> Result<()> {
                     VimMode::Insert => {
                         match key.code {
                             KeyCode::Esc => {
-                                app.vim_mode = VimMode::Normal;
+                                if app.chat_input.is_empty() {
+                                    app.vim_mode = VimMode::Normal;
+                                } else {
+                                    app.chat_input.clear();
+                                    app.slash_completions.clear();
+                                }
                             }
                             KeyCode::Enter => {
-                                app.send_chat().await;
+                                if app.chat_input.starts_with('/') {
+                                    let parsed = slash::parse(&app.chat_input);
+                                    app.handle_slash(parsed).await;
+                                } else {
+                                    app.send_chat().await;
+                                }
+                                app.chat_input.clear();
+                                app.slash_completions.clear();
                             }
                             KeyCode::Backspace => {
                                 app.chat_input.pop();
+                                app.refresh_slash_completions();
                             }
                             KeyCode::Tab => {
-                                let screens = Screen::all();
-                                let idx = screens.iter().position(|s| *s == app.screen).unwrap_or(0);
-                                navigate_to(&mut app, screens[(idx + 1) % screens.len()]);
+                                if !app.slash_completions.is_empty() {
+                                    let pick = &app.slash_completions[app.slash_selected].0;
+                                    app.chat_input = format!("/{} ", pick);
+                                    app.refresh_slash_completions();
+                                } else {
+                                    let screens = Screen::all();
+                                    let idx = screens.iter().position(|s| *s == app.screen).unwrap_or(0);
+                                    navigate_to(&mut app, screens[(idx + 1) % screens.len()]);
+                                }
+                            }
+                            KeyCode::Up => {
+                                if app.slash_selected > 0 {
+                                    app.slash_selected -= 1;
+                                }
+                            }
+                            KeyCode::Down => {
+                                if app.slash_selected + 1 < app.slash_completions.len() {
+                                    app.slash_selected += 1;
+                                }
                             }
                             KeyCode::Char(c) => {
                                 app.chat_input.push(c);
+                                app.refresh_slash_completions();
                             }
                             _ => {}
                         }
@@ -1109,6 +1420,131 @@ fn draw(f: &mut Frame, app: &App) {
             .block(footer),
         chunks[2],
     );
+
+    let status_input = status::StatusInput {
+        engine_healthy: app.healthy,
+        worker_count: app.worker_count,
+        agent: if app.chat_agent.is_empty() { "default" } else { &app.chat_agent },
+        realm: &app.chat_realm,
+        session_active: app.chat_streaming,
+        pending_approvals: app.approvals.len(),
+        hint: "?:help  Ctrl+P:palette  Ctrl+W:workers",
+    };
+    let status_area = Rect {
+        x: chunks[0].x + 1,
+        y: chunks[0].y + 1,
+        width: chunks[0].width.saturating_sub(2),
+        height: 1,
+    };
+    status::draw(f, status_area, &status_input);
+
+    let area = f.area();
+    if app.show_first_run {
+        let hs = first_run::detect(app.healthy, app.worker_count);
+        match hs {
+            first_run::HealthState::EngineDown => first_run::draw_engine_down(f, area),
+            first_run::HealthState::EngineUpNoWorkers => first_run::draw_no_workers(f, area),
+            first_run::HealthState::Ready => {}
+        }
+    }
+    if app.show_help {
+        help_overlay::draw(f, area);
+    }
+    if app.show_palette {
+        let items = app.palette_items();
+        palette::draw(f, area, &app.palette_query, &items, app.palette_selected);
+    }
+    if app.show_worker_picker {
+        draw_worker_picker(f, app, area);
+    }
+    if !app.slash_completions.is_empty() && app.screen == Screen::Chat {
+        draw_slash_completions(f, app, area);
+    }
+}
+
+fn draw_slash_completions(f: &mut Frame, app: &App, area: Rect) {
+    let h = (app.slash_completions.len() as u16 + 2).min(12);
+    let popup = Rect {
+        x: area.x + 4,
+        y: area.bottom().saturating_sub(h + 5),
+        width: area.width.saturating_sub(8),
+        height: h,
+    };
+    f.render_widget(Clear, popup);
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, (name, hint)) in app.slash_completions.iter().enumerate() {
+        let style = if i == app.slash_selected {
+            Style::default().bg(theme::EMBER).fg(theme::PAPER).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  /{:<16}", name), style),
+            Span::styled(format!("  {}", hint), theme::dim()),
+        ]));
+    }
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::dim())
+        .title(Span::styled(" Tab to complete ", theme::eyebrow()));
+    f.render_widget(Paragraph::new(lines).block(block), popup);
+}
+
+fn draw_worker_picker(f: &mut Frame, app: &App, area: Rect) {
+    let popup = help_overlay::centered_rect(70, 70, area);
+    f.render_widget(Clear, popup);
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled("AGENTOS · WORKER PICKER", theme::eyebrow())),
+        Line::raw(""),
+    ];
+    if app.worker_catalog.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No catalog available. Engine must expose /api/workers/catalog.",
+            theme::dim(),
+        )));
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            "  Manual install: cargo build --release -p <worker-name>",
+            theme::accent(),
+        )));
+    } else {
+        for (i, card) in app.worker_catalog.iter().enumerate() {
+            let style = if i == app.worker_picker_selected {
+                Style::default().bg(theme::EMBER).fg(theme::PAPER).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let badge = if card.installed { "● installed" } else { "○ available" };
+            let badge_style = if card.installed { theme::ok() } else { theme::dim() };
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {:<24}", card.name), style),
+                Span::styled(format!("  {}", badge), badge_style),
+                Span::styled(format!("  {}", card.description), theme::dim()),
+            ]));
+        }
+        lines.push(Line::raw(""));
+        if let Some(card) = app.worker_catalog.get(app.worker_picker_selected) {
+            lines.push(Line::from(Span::styled(
+                format!("  Functions: {}", card.functions.join(", ")),
+                theme::dim(),
+            )));
+            lines.push(Line::raw(""));
+            lines.push(Line::from(Span::styled(
+                format!("  Enter: {}", worker_picker::install_command(card)),
+                theme::accent(),
+            )));
+        }
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        "  Esc to close · ↑↓ to pick · Enter to copy install command",
+        theme::dim(),
+    )));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(Span::styled(" Workers ", theme::title()));
+    f.render_widget(Paragraph::new(lines).block(block).wrap(Wrap { trim: false }), popup);
 }
 
 fn draw_dashboard(f: &mut Frame, app: &App, block: Block, area: Rect) {
@@ -1242,34 +1678,60 @@ fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
     let mut messages: Vec<Line> = vec![];
     for (idx, (role, msg)) in app.chat_messages.iter().enumerate() {
         let (prefix, color) = match role.as_str() {
-            "user" => ("You: ", Color::Cyan),
-            "assistant" => ("Agent: ", Color::Green),
-            _ => ("System: ", Color::Yellow),
+            "user" => ("you  ", theme::EMBER),
+            "assistant" => ("agent  ", theme::INK),
+            _ => ("·  ", theme::MUTED),
         };
 
         let is_last = idx == app.chat_messages.len() - 1;
         let is_streaming_msg = is_last && app.chat_streaming && msg == "(thinking...)";
 
+        messages.push(Line::from(Span::styled(
+            prefix,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        )));
+
         if is_streaming_msg {
             messages.push(Line::from(vec![
-                Span::styled(prefix, Style::default().fg(color).add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
                 Span::styled(
                     format!("{} thinking...", SPINNER_FRAMES[app.spinner_frame]),
-                    Style::default().fg(Color::Cyan),
+                    theme::dim(),
                 ),
             ]));
+        } else if role == "assistant" {
+            for line in markdown::render(msg) {
+                let mut spans: Vec<Span> = vec![Span::raw("  ")];
+                spans.extend(line.spans);
+                messages.push(Line::from(spans));
+            }
         } else {
-            messages.push(Line::from(vec![
-                Span::styled(prefix, Style::default().fg(color).add_modifier(Modifier::BOLD)),
-                Span::raw(msg.as_str()),
-            ]));
+            messages.push(Line::from(vec![Span::raw("  "), Span::raw(msg.clone())]));
         }
+        messages.push(Line::raw(""));
     }
 
     if messages.is_empty() {
         messages.push(Line::from(Span::styled(
-            "  No messages yet. Type a message and press Enter.",
-            Style::default().fg(Color::DarkGray),
+            "AGENTOS · CHAT",
+            theme::eyebrow(),
+        )));
+        messages.push(Line::raw(""));
+        messages.push(Line::from(Span::styled(
+            "  Type a message — or a slash command:",
+            theme::dim(),
+        )));
+        messages.push(Line::raw(""));
+        for spec in slash::BUILTINS.iter().take(7) {
+            messages.push(Line::from(vec![
+                Span::styled(format!("    /{:<10}", spec.name), theme::accent()),
+                Span::styled(format!("  {}", spec.help), theme::dim()),
+            ]));
+        }
+        messages.push(Line::raw(""));
+        messages.push(Line::from(Span::styled(
+            "  Press ? for full keymap, Ctrl+W to browse workers.",
+            theme::dim(),
         )));
     }
 
@@ -1283,20 +1745,26 @@ fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
 
     let msg_block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Chat -> {} ", agent_label));
+        .border_style(theme::dim())
+        .title(Span::styled(
+            format!(" chat · {} · {} ", agent_label, app.chat_realm),
+            theme::eyebrow(),
+        ));
     f.render_widget(Paragraph::new(messages).block(msg_block).wrap(Wrap { trim: false }), chat_chunks[0]);
 
     let mode_label = match app.vim_mode {
-        VimMode::Normal => Span::styled(" [NORMAL] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-        VimMode::Insert => Span::styled(" [INSERT] ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        VimMode::Normal => Span::styled(" NORMAL ", theme::warn()),
+        VimMode::Insert => Span::styled(" INSERT ", theme::accent()),
     };
 
+    let border_color = if app.chat_input.starts_with('/') { theme::EMBER } else { theme::INK };
     let input_block = Block::default()
         .borders(Borders::ALL)
         .title(mode_label)
-        .border_style(Style::default().fg(if app.vim_mode == VimMode::Insert { Color::Cyan } else { Color::Yellow }));
-    let cursor_char = if app.vim_mode == VimMode::Insert { "_" } else { "\u{2588}" };
-    let cursor_text = format!("{}{}", app.chat_input, cursor_char);
+        .border_style(Style::default().fg(border_color));
+    let cursor_char = if app.vim_mode == VimMode::Insert { "▎" } else { "█" };
+    let prefix = if app.chat_input.starts_with('/') { "" } else { "> " };
+    let cursor_text = format!("{}{}{}", prefix, app.chat_input, cursor_char);
     f.render_widget(Paragraph::new(cursor_text).block(input_block), chat_chunks[1]);
 
     let mut status_spans = vec![];
@@ -2408,7 +2876,7 @@ mod tests {
     #[test]
     fn test_app_new_defaults() {
         let app = App::new();
-        assert_eq!(app.screen, Screen::Dashboard);
+        assert_eq!(app.screen, Screen::Chat);
         assert_eq!(app.selected, 0);
         assert!(!app.healthy);
         assert!(app.agents.is_empty());
@@ -2421,6 +2889,22 @@ mod tests {
         assert!(app.orchestrator_plans.is_empty());
         assert!(!app.approval_mode);
         assert!(app.pending_chord.is_none());
+        assert!(app.show_first_run);
+        assert!(!app.show_help);
+        assert!(!app.show_palette);
+    }
+
+    #[test]
+    fn test_chat_realm_default() {
+        let app = App::new();
+        assert_eq!(app.chat_realm, "default");
+    }
+
+    #[test]
+    fn test_palette_items_cover_all_screens() {
+        let app = App::new();
+        let items = app.palette_items();
+        assert_eq!(items.len(), Screen::all().len());
     }
 
     #[test]

--- a/crates/tui/src/markdown.rs
+++ b/crates/tui/src/markdown.rs
@@ -1,0 +1,168 @@
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use crate::theme;
+
+pub fn render(body: &str) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let mut in_code = false;
+
+    for raw in body.split('\n') {
+        let line = raw.to_string();
+
+        if let Some(rest) = line.strip_prefix("```") {
+            in_code = !in_code;
+            let lang = if in_code { rest.trim().to_string() } else { String::new() };
+            out.push(Line::from(Span::styled(
+                if in_code {
+                    format!("┌─ {}", if lang.is_empty() { "code" } else { lang.as_str() })
+                } else {
+                    "└─".to_string()
+                },
+                Style::default().fg(theme::MUTED),
+            )));
+            continue;
+        }
+
+        if in_code {
+            out.push(Line::from(Span::styled(
+                format!("│ {}", line),
+                Style::default().fg(Color::Rgb(0x33, 0x52, 0x74)),
+            )));
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("# ") {
+            out.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme::INK).add_modifier(Modifier::BOLD),
+            )));
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("## ") {
+            out.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme::EMBER).add_modifier(Modifier::BOLD),
+            )));
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("### ") {
+            out.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme::INK).add_modifier(Modifier::BOLD),
+            )));
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
+            out.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(theme::EMBER)),
+                Span::raw(rest.to_string()),
+            ]));
+            continue;
+        }
+        if line.starts_with("> ") {
+            out.push(Line::from(vec![
+                Span::styled("│ ", Style::default().fg(theme::MUTED)),
+                Span::styled(
+                    line[2..].to_string(),
+                    Style::default().fg(theme::MUTED).add_modifier(Modifier::ITALIC),
+                ),
+            ]));
+            continue;
+        }
+
+        out.push(render_inline(&line));
+    }
+    out
+}
+
+fn render_inline(line: &str) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut buf = String::new();
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '`' {
+            if !buf.is_empty() {
+                spans.push(Span::raw(std::mem::take(&mut buf)));
+            }
+            let mut code = String::new();
+            for cc in chars.by_ref() {
+                if cc == '`' { break; }
+                code.push(cc);
+            }
+            spans.push(Span::styled(
+                code,
+                Style::default().fg(Color::Rgb(0x33, 0x52, 0x74)).add_modifier(Modifier::BOLD),
+            ));
+        } else if c == '*' && chars.peek() == Some(&'*') {
+            chars.next();
+            if !buf.is_empty() {
+                spans.push(Span::raw(std::mem::take(&mut buf)));
+            }
+            let mut bold = String::new();
+            while let Some(&cc) = chars.peek() {
+                chars.next();
+                if cc == '*' && chars.peek() == Some(&'*') {
+                    chars.next();
+                    break;
+                }
+                bold.push(cc);
+            }
+            spans.push(Span::styled(
+                bold,
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+        } else {
+            buf.push(c);
+        }
+    }
+    if !buf.is_empty() {
+        spans.push(Span::raw(buf));
+    }
+    if spans.is_empty() {
+        spans.push(Span::raw(String::new()));
+    }
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_line_passes_through() {
+        let out = render("hello world");
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn h1_styled() {
+        let out = render("# Title");
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn fenced_code_wraps_in_borders() {
+        let out = render("```rust\nfn main() {}\n```");
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn bullet_renders() {
+        let out = render("- item one");
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn inline_code_splits_spans() {
+        let line = render_inline("call `foo()` now");
+        assert!(line.spans.len() >= 3);
+    }
+
+    #[test]
+    fn bold_inline() {
+        let line = render_inline("**hi** there");
+        assert!(line.spans.len() >= 2);
+    }
+}

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -1,0 +1,106 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::help_overlay::centered_rect;
+use crate::slash::fuzzy_match;
+use crate::theme;
+
+#[derive(Debug, Clone)]
+pub struct PaletteItem {
+    pub label: String,
+    pub hint: String,
+    pub action_key: String,
+}
+
+pub fn rank(items: &[PaletteItem], query: &str) -> Vec<(usize, i32)> {
+    let mut scored: Vec<(usize, i32)> = items
+        .iter()
+        .enumerate()
+        .filter_map(|(i, it)| fuzzy_match(query, &it.label).map(|s| (i, s)))
+        .collect();
+    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored
+}
+
+pub fn draw(f: &mut Frame, area: Rect, query: &str, items: &[PaletteItem], selected: usize) {
+    let popup = centered_rect(60, 60, area);
+    f.render_widget(Clear, popup);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(popup);
+
+    let input_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::accent())
+        .title(Span::styled(" Command palette ", theme::title()));
+    f.render_widget(
+        Paragraph::new(format!("> {}_", query)).block(input_block),
+        chunks[0],
+    );
+
+    let ranked = rank(items, query);
+    let mut lines: Vec<Line> = Vec::new();
+    for (rank_idx, (item_idx, _)) in ranked.iter().take(20).enumerate() {
+        let item = &items[*item_idx];
+        let style = if rank_idx == selected {
+            Style::default().bg(theme::EMBER).fg(theme::PAPER).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {:<24}", item.label), style),
+            Span::styled(format!("  {}", item.hint), theme::dim()),
+            Span::styled(format!("    {}", item.action_key), theme::eyebrow()),
+        ]));
+    }
+    if ranked.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No matches.",
+            theme::dim(),
+        )));
+    }
+
+    let list_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme::dim());
+    f.render_widget(Paragraph::new(lines).block(list_block), chunks[1]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<PaletteItem> {
+        vec![
+            PaletteItem { label: "Chat".into(), hint: "chat with agent".into(), action_key: "3".into() },
+            PaletteItem { label: "Memory".into(), hint: "store + recall".into(), action_key: "m".into() },
+            PaletteItem { label: "Approvals".into(), hint: "pending requests".into(), action_key: "9".into() },
+        ]
+    }
+
+    #[test]
+    fn rank_empty_query_returns_all() {
+        let r = rank(&sample(), "");
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    fn rank_filters_by_match() {
+        let r = rank(&sample(), "mem");
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].0, 1);
+    }
+
+    #[test]
+    fn rank_sorts_best_first() {
+        let r = rank(&sample(), "a");
+        assert!(!r.is_empty());
+    }
+}

--- a/crates/tui/src/slash.rs
+++ b/crates/tui/src/slash.rs
@@ -1,0 +1,181 @@
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SlashSpec {
+    pub name: &'static str,
+    pub args: &'static str,
+    pub help: &'static str,
+}
+
+pub const BUILTINS: &[SlashSpec] = &[
+    SlashSpec { name: "agent", args: "<id>", help: "Switch active agent" },
+    SlashSpec { name: "realm", args: "<name>", help: "Switch realm context" },
+    SlashSpec { name: "memory", args: "<query>", help: "Recall from memory worker" },
+    SlashSpec { name: "remember", args: "<text>", help: "Store memory in current namespace" },
+    SlashSpec { name: "hand", args: "<name>", help: "Run a configured hand bundle" },
+    SlashSpec { name: "skill", args: "<id>", help: "Invoke a skill (skillkit-bridge)" },
+    SlashSpec { name: "worker", args: "list|add|info <name>", help: "Browse + install workers" },
+    SlashSpec { name: "channel", args: "<provider> <msg>", help: "Send via a channel worker" },
+    SlashSpec { name: "approve", args: "<id>", help: "Approve a pending request" },
+    SlashSpec { name: "deny", args: "<id>", help: "Deny a pending request" },
+    SlashSpec { name: "clear", args: "", help: "Clear chat scrollback" },
+    SlashSpec { name: "help", args: "", help: "Show keymap + commands" },
+    SlashSpec { name: "quit", args: "", help: "Exit TUI" },
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Parsed {
+    Plain(String),
+    Cmd { name: String, args: String },
+    Incomplete { partial: String },
+}
+
+pub fn parse(input: &str) -> Parsed {
+    let trimmed = input.trim_start();
+    if !trimmed.starts_with('/') {
+        return Parsed::Plain(input.to_string());
+    }
+    let body = &trimmed[1..];
+    if body.is_empty() {
+        return Parsed::Incomplete { partial: String::new() };
+    }
+    match body.split_once(char::is_whitespace) {
+        Some((name, rest)) => Parsed::Cmd {
+            name: name.to_string(),
+            args: rest.trim().to_string(),
+        },
+        None => Parsed::Incomplete { partial: body.to_string() },
+    }
+}
+
+pub fn fuzzy_match(needle: &str, hay: &str) -> Option<i32> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    let n = needle.to_lowercase();
+    let h = hay.to_lowercase();
+    if h.starts_with(&n) {
+        return Some(1000 - hay.len() as i32);
+    }
+    if h.contains(&n) {
+        return Some(500 - hay.len() as i32);
+    }
+    let mut hi = h.chars();
+    let mut score: i32 = 0;
+    let mut last = -1i32;
+    for (idx, c) in n.chars().enumerate() {
+        let mut found = false;
+        for (j, hc) in hi.by_ref().enumerate() {
+            if hc == c {
+                let pos = idx as i32 + j as i32;
+                if last >= 0 && pos == last + 1 {
+                    score += 5;
+                }
+                last = pos;
+                score += 1;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return None;
+        }
+    }
+    Some(score)
+}
+
+pub fn complete(partial: &str, registry_fns: &[String]) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String, i32)> = Vec::new();
+
+    for spec in BUILTINS {
+        if let Some(score) = fuzzy_match(partial, spec.name) {
+            out.push((
+                spec.name.to_string(),
+                format!("{} — {}", spec.args, spec.help),
+                score + 100,
+            ));
+        }
+    }
+
+    for fname in registry_fns {
+        let display_name = fname.replace("::", ".");
+        if let Some(score) = fuzzy_match(partial, &display_name) {
+            out.push((display_name.clone(), "function".into(), score));
+        }
+    }
+
+    out.sort_by(|a, b| b.2.cmp(&a.2));
+    out.truncate(10);
+    out.into_iter().map(|(n, h, _)| (n, h)).collect()
+}
+
+pub fn extract_function_names(functions_json: &Value) -> Vec<String> {
+    let arr = match functions_json.as_array() {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    arr.iter()
+        .filter_map(|v| {
+            v.get("id")
+                .or_else(|| v.get("name"))
+                .and_then(|s| s.as_str())
+                .map(String::from)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain() {
+        assert_eq!(parse("hello"), Parsed::Plain("hello".into()));
+    }
+
+    #[test]
+    fn parses_cmd_with_args() {
+        match parse("/agent foo") {
+            Parsed::Cmd { name, args } => {
+                assert_eq!(name, "agent");
+                assert_eq!(args, "foo");
+            }
+            _ => panic!("expected Cmd"),
+        }
+    }
+
+    #[test]
+    fn parses_incomplete() {
+        assert_eq!(parse("/age"), Parsed::Incomplete { partial: "age".into() });
+    }
+
+    #[test]
+    fn fuzzy_prefix_outranks_substring() {
+        let prefix = fuzzy_match("age", "agent").unwrap();
+        let sub = fuzzy_match("nt", "agent").unwrap();
+        assert!(prefix > sub);
+    }
+
+    #[test]
+    fn complete_finds_builtin() {
+        let suggestions = complete("ag", &[]);
+        assert!(suggestions.iter().any(|(n, _)| n == "agent"));
+    }
+
+    #[test]
+    fn complete_includes_registry_fns() {
+        let regs = vec!["memory::store".to_string(), "browser::navigate".into()];
+        let s = complete("memory", &regs);
+        assert!(s.iter().any(|(n, _)| n == "memory.store"));
+    }
+
+    #[test]
+    fn extract_names_handles_id_and_name() {
+        let v: Value = serde_json::from_str(
+            r#"[{"id":"a::x"}, {"name":"b::y"}, {"x":"skip"}]"#,
+        )
+        .unwrap();
+        let names = extract_function_names(&v);
+        assert_eq!(names, vec!["a::x", "b::y"]);
+    }
+}

--- a/crates/tui/src/sse.rs
+++ b/crates/tui/src/sse.rs
@@ -1,0 +1,154 @@
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Result};
+use futures_util::StreamExt;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    Token(String),
+    ToolCall { id: String, function: String, args: Value },
+    Approval { id: String, function: String, agent: String },
+    Done { tokens: usize, ms: u64 },
+    Error(String),
+    Heartbeat,
+}
+
+pub async fn subscribe(stream_base: &str, session_id: &str, tx: mpsc::Sender<StreamEvent>) -> Result<()> {
+    let url = format!("{}/agent/events?session={}", stream_base, session_id);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(0))
+        .build()?;
+    let resp = client.get(&url).send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("SSE subscribe HTTP {}", resp.status()));
+    }
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+        loop {
+            let Some(idx) = buf.find("\n\n") else { break; };
+            let frame = buf.drain(..idx + 2).collect::<String>();
+            if let Some(evt) = parse_frame(&frame) {
+                if tx.send(evt).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn parse_frame(frame: &str) -> Option<StreamEvent> {
+    let mut event = "message".to_string();
+    let mut data = String::new();
+    for line in frame.split('\n') {
+        if let Some(rest) = line.strip_prefix("event:") {
+            event = rest.trim().to_string();
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(rest.trim_start());
+        }
+    }
+    if data.is_empty() && event != "heartbeat" {
+        return None;
+    }
+    match event.as_str() {
+        "token" => Some(StreamEvent::Token(data)),
+        "tool_call" | "function_call" => {
+            let v: Value = serde_json::from_str(&data).ok()?;
+            Some(StreamEvent::ToolCall {
+                id: v["id"].as_str().unwrap_or("").to_string(),
+                function: v["function"].as_str().or_else(|| v["name"].as_str()).unwrap_or("").to_string(),
+                args: v["args"].clone(),
+            })
+        }
+        "approval" => {
+            let v: Value = serde_json::from_str(&data).ok()?;
+            Some(StreamEvent::Approval {
+                id: v["id"].as_str().unwrap_or("").to_string(),
+                function: v["function"].as_str().unwrap_or("").to_string(),
+                agent: v["agent"].as_str().unwrap_or("").to_string(),
+            })
+        }
+        "done" => {
+            let v: Value = serde_json::from_str(&data).unwrap_or(Value::Null);
+            Some(StreamEvent::Done {
+                tokens: v["tokens"].as_u64().unwrap_or(0) as usize,
+                ms: v["ms"].as_u64().unwrap_or(0),
+            })
+        }
+        "error" => Some(StreamEvent::Error(data)),
+        "heartbeat" => Some(StreamEvent::Heartbeat),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_token_frame() {
+        let f = "event: token\ndata: hello\n\n";
+        match parse_frame(f) {
+            Some(StreamEvent::Token(s)) => assert_eq!(s, "hello"),
+            _ => panic!("expected Token"),
+        }
+    }
+
+    #[test]
+    fn parses_done_frame() {
+        let f = "event: done\ndata: {\"tokens\":42,\"ms\":1500}\n\n";
+        match parse_frame(f) {
+            Some(StreamEvent::Done { tokens, ms }) => {
+                assert_eq!(tokens, 42);
+                assert_eq!(ms, 1500);
+            }
+            _ => panic!("expected Done"),
+        }
+    }
+
+    #[test]
+    fn parses_approval_frame() {
+        let f = "event: approval\ndata: {\"id\":\"a1\",\"function\":\"browser::navigate\",\"agent\":\"shopper\"}\n\n";
+        match parse_frame(f) {
+            Some(StreamEvent::Approval { id, function, agent }) => {
+                assert_eq!(id, "a1");
+                assert_eq!(function, "browser::navigate");
+                assert_eq!(agent, "shopper");
+            }
+            _ => panic!("expected Approval"),
+        }
+    }
+
+    #[test]
+    fn ignores_empty_data() {
+        let f = "event: token\ndata: \n\n";
+        assert!(parse_frame(f).is_none());
+    }
+
+    #[test]
+    fn heartbeat_with_no_data_ok() {
+        let f = "event: heartbeat\n\n";
+        match parse_frame(f) {
+            Some(StreamEvent::Heartbeat) => {}
+            _ => panic!("expected Heartbeat"),
+        }
+    }
+
+    #[test]
+    fn multiline_data() {
+        let f = "event: token\ndata: line1\ndata: line2\n\n";
+        match parse_frame(f) {
+            Some(StreamEvent::Token(s)) => assert_eq!(s, "line1\nline2"),
+            _ => panic!("expected Token"),
+        }
+    }
+}

--- a/crates/tui/src/status.rs
+++ b/crates/tui/src/status.rs
@@ -1,0 +1,131 @@
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::theme;
+
+#[derive(Debug, Clone)]
+pub struct StatusInput<'a> {
+    pub engine_healthy: bool,
+    pub worker_count: usize,
+    pub agent: &'a str,
+    pub realm: &'a str,
+    pub session_active: bool,
+    pub pending_approvals: usize,
+    pub hint: &'a str,
+}
+
+pub fn render(input: &StatusInput) -> Line<'static> {
+    let dot = if input.engine_healthy {
+        Span::styled("● ", theme::ok())
+    } else {
+        Span::styled("○ ", theme::err())
+    };
+    let engine_lbl = if input.engine_healthy {
+        Span::styled("engine ", theme::dim())
+    } else {
+        Span::styled("offline ", theme::err())
+    };
+    let workers = Span::styled(
+        format!("{} workers ", input.worker_count),
+        theme::dim(),
+    );
+    let agent = Span::styled(
+        format!("· agent: {} ", input.agent),
+        theme::accent(),
+    );
+    let realm = Span::styled(
+        format!("· realm: {} ", input.realm),
+        theme::dim(),
+    );
+    let session = if input.session_active {
+        Span::styled("· streaming ", theme::ok())
+    } else {
+        Span::raw("")
+    };
+    let approvals = if input.pending_approvals > 0 {
+        Span::styled(
+            format!("· {} approvals pending ", input.pending_approvals),
+            theme::warn(),
+        )
+    } else {
+        Span::raw("")
+    };
+    let hint = Span::styled(format!("  {}", input.hint), theme::eyebrow());
+
+    Line::from(vec![dot, engine_lbl, workers, agent, realm, session, approvals, hint])
+}
+
+pub fn draw(f: &mut Frame, area: Rect, input: &StatusInput) {
+    let line = render(input);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_engine_renders_dot() {
+        let line = render(&StatusInput {
+            engine_healthy: true,
+            worker_count: 65,
+            agent: "default",
+            realm: "prod",
+            session_active: false,
+            pending_approvals: 0,
+            hint: "?",
+        });
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("65 workers"));
+        assert!(txt.contains("default"));
+    }
+
+    #[test]
+    fn offline_shows_offline() {
+        let line = render(&StatusInput {
+            engine_healthy: false,
+            worker_count: 0,
+            agent: "-",
+            realm: "-",
+            session_active: false,
+            pending_approvals: 0,
+            hint: "",
+        });
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("offline"));
+    }
+
+    #[test]
+    fn pending_approvals_shows_warn() {
+        let line = render(&StatusInput {
+            engine_healthy: true,
+            worker_count: 1,
+            agent: "a",
+            realm: "r",
+            session_active: false,
+            pending_approvals: 3,
+            hint: "",
+        });
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("3 approvals pending"));
+    }
+
+    #[test]
+    fn streaming_shows_when_session_active() {
+        let line = render(&StatusInput {
+            engine_healthy: true,
+            worker_count: 1,
+            agent: "a",
+            realm: "r",
+            session_active: true,
+            pending_approvals: 0,
+            hint: "",
+        });
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("streaming"));
+    }
+}

--- a/crates/tui/src/theme.rs
+++ b/crates/tui/src/theme.rs
@@ -1,0 +1,39 @@
+use ratatui::style::{Color, Modifier, Style};
+
+pub const PAPER: Color = Color::Rgb(0xf2, 0xed, 0xe1);
+pub const INK: Color = Color::Rgb(0x0c, 0x0b, 0x0a);
+pub const MUTED: Color = Color::Rgb(0x6b, 0x66, 0x60);
+pub const EMBER: Color = Color::Rgb(0xd9, 0x6e, 0x2e);
+#[allow(dead_code)]
+pub const RULE: Color = Color::Rgb(0xc8, 0xc1, 0xb4);
+pub const OK: Color = Color::Rgb(0x4f, 0x8a, 0x5a);
+pub const WARN: Color = Color::Rgb(0xc7, 0x8c, 0x32);
+pub const ERR: Color = Color::Rgb(0xb6, 0x3a, 0x2f);
+
+pub fn eyebrow() -> Style {
+    Style::default().fg(MUTED).add_modifier(Modifier::DIM)
+}
+
+pub fn title() -> Style {
+    Style::default().fg(INK).add_modifier(Modifier::BOLD)
+}
+
+pub fn accent() -> Style {
+    Style::default().fg(EMBER).add_modifier(Modifier::BOLD)
+}
+
+pub fn dim() -> Style {
+    Style::default().fg(MUTED)
+}
+
+pub fn ok() -> Style {
+    Style::default().fg(OK)
+}
+
+pub fn warn() -> Style {
+    Style::default().fg(WARN)
+}
+
+pub fn err() -> Style {
+    Style::default().fg(ERR)
+}

--- a/crates/tui/src/worker_picker.rs
+++ b/crates/tui/src/worker_picker.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkerCard {
+    pub name: String,
+    pub description: String,
+    pub functions: Vec<String>,
+    pub installed: bool,
+    pub binary_path: Option<String>,
+}
+
+pub fn parse_catalog(api_response: &Value, installed: &[String]) -> Vec<WorkerCard> {
+    let arr = match api_response.as_array() {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    let installed_set: std::collections::HashSet<&str> =
+        installed.iter().map(|s| s.as_str()).collect();
+    arr.iter()
+        .filter_map(|v| {
+            let name = v.get("name").and_then(|s| s.as_str())?.to_string();
+            let description = v
+                .get("description")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string();
+            let functions: Vec<String> = v
+                .get("functions")
+                .and_then(|f| f.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let installed = installed_set.contains(name.as_str());
+            Some(WorkerCard {
+                name,
+                description,
+                functions,
+                installed,
+                binary_path: v
+                    .get("binary_path")
+                    .and_then(|s| s.as_str())
+                    .map(String::from),
+            })
+        })
+        .collect()
+}
+
+pub fn install_command(card: &WorkerCard) -> String {
+    if card.installed {
+        format!(
+            "$ {}",
+            card.binary_path.clone().unwrap_or_else(|| format!("./target/release/{}", card.name))
+        )
+    } else {
+        format!(
+            "$ cargo build --release -p {} && ./target/release/{}",
+            card.name, card.name
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_card() {
+        let v: Value = serde_json::from_str(
+            r#"[{"name":"memory","description":"persistent recall","functions":["memory::store","memory::recall"]}]"#,
+        )
+        .unwrap();
+        let cards = parse_catalog(&v, &[]);
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].name, "memory");
+        assert_eq!(cards[0].functions.len(), 2);
+        assert!(!cards[0].installed);
+    }
+
+    #[test]
+    fn marks_installed() {
+        let v: Value = serde_json::from_str(r#"[{"name":"browser"}]"#).unwrap();
+        let cards = parse_catalog(&v, &["browser".to_string()]);
+        assert!(cards[0].installed);
+    }
+
+    #[test]
+    fn install_cmd_for_uninstalled() {
+        let card = WorkerCard {
+            name: "memory".into(),
+            description: "".into(),
+            functions: vec![],
+            installed: false,
+            binary_path: None,
+        };
+        let cmd = install_command(&card);
+        assert!(cmd.contains("cargo build"));
+        assert!(cmd.contains("memory"));
+    }
+
+    #[test]
+    fn install_cmd_for_installed_uses_binary() {
+        let card = WorkerCard {
+            name: "memory".into(),
+            description: "".into(),
+            functions: vec![],
+            installed: true,
+            binary_path: Some("/opt/memory".into()),
+        };
+        assert_eq!(install_command(&card), "$ /opt/memory");
+    }
+}

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Boot the agentos dev stack: every release worker binary connects to the
+# local iii engine on ws://localhost:49134. Run this in a second terminal
+# after `iii --config config.yaml` is up.
+#
+# Usage:
+#   bash scripts/dev-up.sh           # spawn all release workers in background
+#   bash scripts/dev-up.sh --build   # cargo build --workspace --release first
+#   bash scripts/dev-up.sh stop      # kill anything launched here
+#
+# Env:
+#   III_WS_URL                       (default: ws://localhost:49134)
+#   ANTHROPIC_API_KEY                required for llm-router
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIDFILE="$ROOT/.agentos-dev.pids"
+RELEASE_DIR="$ROOT/target/release"
+
+export III_WS_URL="${III_WS_URL:-ws://localhost:49134}"
+
+stop_workers() {
+    if [[ ! -f "$PIDFILE" ]]; then
+        echo "no PID file at $PIDFILE — nothing to stop"
+        return 0
+    fi
+    while read -r pid; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done < "$PIDFILE"
+    rm -f "$PIDFILE"
+    echo "stopped."
+}
+
+if [[ "${1:-}" == "stop" ]]; then
+    stop_workers
+    exit 0
+fi
+
+if [[ "${1:-}" == "--build" ]]; then
+    echo "▸ cargo build --workspace --release"
+    (cd "$ROOT" && cargo build --workspace --release)
+fi
+
+if [[ ! -d "$RELEASE_DIR" ]]; then
+    echo "no release binaries at $RELEASE_DIR"
+    echo "  run: bash scripts/dev-up.sh --build"
+    exit 1
+fi
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    echo "warning: ANTHROPIC_API_KEY not set — llm-router will fall through to mocks"
+fi
+
+> "$PIDFILE"
+spawned=0
+for bin in "$RELEASE_DIR"/agentos-*; do
+    name="$(basename "$bin")"
+    case "$name" in
+        agentos-tui|agentos-cli|*.d|*.dSYM) continue ;;
+    esac
+    [[ -x "$bin" ]] || continue
+    "$bin" >> "$ROOT/.agentos-${name#agentos-}.log" 2>&1 &
+    echo $! >> "$PIDFILE"
+    spawned=$((spawned + 1))
+done
+
+echo "▸ spawned $spawned workers · pids in $PIDFILE"
+echo "  logs:  $ROOT/.agentos-*.log"
+echo "  stop:  bash scripts/dev-up.sh stop"


### PR DESCRIPTION
## Why

Existing 2,459-LOC ratatui dashboard had 25 panes and no chat-first entry point. Repo-cloners couldn't drive the agent loop without curl. Chat-first refactor inspired in shape (slash commands, autocomplete overlays, differential render mindset) by [pi-mono/packages/tui](https://github.com/badlogic/pi-mono/tree/main/packages/tui), kept native to the workspace (Rust + ratatui).

## What

**New modules under `crates/tui/src/`:**

| Module | Purpose |
|---|---|
| `theme.rs` | design.md tokens — paper, ink, ember, muted, ok / warn / err |
| `slash.rs` | `/` parser + fuzzy autocomplete; 35-function builtin registry |
| `markdown.rs` | headings, fenced code, bullets, inline code & bold → ratatui Lines |
| `sse.rs` | reqwest stream + frame parser for SSE chat |
| `status.rs` | bottom bar: engine dot, worker count, agent, realm, streaming, pending approvals |
| `help_overlay.rs` | `?` modal with the full keymap |
| `first_run.rs` | detects engine-down vs no-workers, shows copy-paste wizard |
| `palette.rs` | `Ctrl+P` fuzzy palette across every pane |
| `worker_picker.rs` | `Ctrl+W` browses 62-worker catalog with cargo install commands |

## Live integration tested

Booted engine + 62 release workers locally (`iii --config config.yaml` + `bash scripts/dev-up.sh`), then ran the TUI's actual code paths against the running stack. Found and fixed every endpoint mismatch:

| TUI was calling | Real endpoint |
|---|---|
| `/api/dashboard/stats` | `/api/realms` + `/api/metrics/summary` |
| `/api/channels` | `/api/coord/channels` |
| `/api/approvals` | `/api/approvals/pending` |
| `/api/memory/recall` | `POST /agentmemory/search` |
| `/api/memory/store` | `POST /agentmemory/remember` |
| `/api/agents/<id>/message` | `POST /api/chat/stream` (SSE) |
| `/iii/functions` | dropped — engine has no introspection HTTP, use static `BUILTIN_REGISTRY_FNS` |
| `/iii/workers` | dropped — bump `worker_count` to ≥1 when `/api/realms` returns 200 |
| `/api/workers/catalog` | dropped — use compile-time `worker_picker::builtin_catalog()` |

## Error empathy

`send_chat` failure paths now surface problem + cause + fix:

- `401/403` → "Anthropic rejected the request. Check ANTHROPIC_API_KEY in agentos/.env"
- `404` → "Endpoint not registered. Is the streaming worker running?"
- `500-599` → "Engine returned a server error. Check llm-router + streaming worker logs"
- `connect` → "Engine not reachable. Run: iii --config config.yaml"

## DX guardrails for users who can't `iii worker add`

| Failure mode | What the TUI shows |
|---|---|
| Engine offline | Centered overlay with `curl install.iii.dev/...` + `iii --config config.yaml` + `bash scripts/dev-up.sh`, dismisses itself once `/api/realms` returns 200 |
| 0 workers | Same overlay variant, points at `dev-up.sh` and `Ctrl+W` |
| User doesn't know commands | Empty Chat shows 7 builtin slash commands; `?` opens full keymap |
| User wants to install a worker | `Ctrl+W` opens 62-card catalog with exact `cargo build` command per worker |

## scripts/dev-up.sh

Spawns every `target/release/agentos-*` binary against `ws://localhost:49134`, supports `--build` and `stop`, writes pids to `.agentos-dev.pids`, ignores `agentos-tui` and `agentos-cli` to avoid spawning interactive bins as workers. `.gitignore` updated to exclude the per-worker logs.

## Tests

- **1321** passing across the workspace (was 1281 — added 40 new tests)
- 5 new unit tests covering `parse_chat_response` (JSON + SSE + raw fallback), builtin registry coverage, worker catalog completeness
- 2 live integration tests gated on `AGENTOS_LIVE_TEST=1`:
  - `live_refresh_health_against_engine` — proves `App.refresh_health()` sets `healthy=true` against `/api/realms`
  - `live_remember_then_recall` — proves `/remember` + `/memory` round-trip data through the agentmemory worker
  - Both passed against a real engine + 62-worker stack
- `cargo build --workspace` clean

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --release` — 1321 passing
- [x] `AGENTOS_LIVE_TEST=1 cargo test -p agentos-tui --release -- --ignored` — both live tests pass with `iii --config config.yaml` + `dev-up.sh` running
- [x] `curl` smoke test of every endpoint the TUI now hits — all return success status
- [x] `cargo run --release -p agentos-tui` against running engine — boots without panic
- [x] README §03 updated to ship TUI as the headline command + `.env.example` step
- [x] `?` toggles keymap overlay, `Ctrl+P` fuzzy pane jump, `Ctrl+W` worker picker
- [x] Slash autocomplete works against builtin registry (offline-safe)
- [x] Banner counter updated to 12 sections